### PR TITLE
Wait for Dataform workflow invocation to finish before notifying ML

### DIFF
--- a/.github/workflows/dataform.yml
+++ b/.github/workflows/dataform.yml
@@ -78,6 +78,43 @@ jobs:
 
           echo "Response: ${EXECUTION}"
 
+          INVOCATION_NAME=$(echo "${EXECUTION}" | jq -r '.name')
+          if [ -z "${INVOCATION_NAME}" ] || [ "${INVOCATION_NAME}" == "null" ]; then
+            echo "Failed to start workflow invocation"
+            exit 1
+          fi
+
+          # Poll until terminal state. The workflowInvocations POST returns
+          # immediately with state=RUNNING; downstream consumers (e.g. game
+          # embeddings) read tables this workflow refreshes, so we MUST wait
+          # for SUCCEEDED before letting the job exit.
+          for i in $(seq 1 90); do
+            sleep 10
+            ACCESS_TOKEN=$(gcloud auth print-access-token)
+            STATUS=$(curl -s "https://dataform.googleapis.com/v1beta1/${INVOCATION_NAME}" \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" | jq -r '.state')
+            echo "Poll $i: state=${STATUS}"
+            case "${STATUS}" in
+              SUCCEEDED)
+                echo "Dataform workflow invocation succeeded"
+                exit 0
+                ;;
+              FAILED|CANCELLED)
+                echo "Dataform workflow invocation ended with state=${STATUS}"
+                exit 1
+                ;;
+              RUNNING|CANCELING)
+                ;;
+              *)
+                echo "Unexpected state: ${STATUS}"
+                exit 1
+                ;;
+            esac
+          done
+
+          echo "Timed out waiting for Dataform workflow invocation to finish"
+          exit 1
+
       - name: Notify ML Pipeline
         if: success() && github.ref == 'refs/heads/main'
         env:


### PR DESCRIPTION
## Summary
- Make the Dataform workflow actually wait for its invocation to finish before dispatching downstream events to bgg-predictive-models.
- Fixes the race that produced \`HTTP 500: No valid embeddings found in data\` in the game-embeddings workflow on 2026-05-02 07:01.

## Background
The Dataform \`workflowInvocations\` REST API is async: POST returns immediately with \`state=RUNNING\`, while the SQL transforms keep running in the background. The \"Execute Workflow\" step here was treating that POST as fire-and-forget, so the very next step (\"Notify ML Pipeline\") was dispatching \`dataform_text_embeddings_ready\` (and \`dataform_complexity_ready\`) within ~50ms of submission — while Dataform was still running.

This silently undermined the prior chain fix in [bgg-predictive-models@292c0ff](https://github.com/phenrickson/bgg-predictive-models/commit/292c0ff). The chain order (\`text_embeddings_complete → dataform → game_embeddings\`) was correct, but Dataform never actually had time to refresh \`predictions.bgg_description_embeddings\` before the embeddings service ran, so it found no rows to work with.

Evidence from the failed run (warehouse run 25246382970):
- \`07:01:44.49\` Dataform POST returns \`state: RUNNING\`
- \`07:01:44.50\` \`Dispatching event: dataform_text_embeddings_ready\` (~50ms later)
- \`07:01:46\` Game Embeddings starts
- \`07:03:15\` Game Embeddings fails with HTTP 500 \"No valid embeddings found in data\"

## What changed
After submitting the invocation, parse \`.name\` from the response and poll \`GET /v1beta1/{name}\` every 10s until state is terminal:
- \`SUCCEEDED\` → exit 0, downstream dispatch fires
- \`FAILED\` / \`CANCELLED\` → exit 1, no downstream dispatch
- \`RUNNING\` / \`CANCELING\` → keep polling
- 15-minute cap (90 × 10s); current runs take ~1m so this is generous

This also closes the same latent race in the \`complexity_complete → dataform_complexity_ready → scoring\` chain.

## Test plan
- [ ] Merge and let the next scheduled cycle run end-to-end (text embeddings → dataform → game embeddings)
- [ ] Confirm the \"Execute Workflow\" step shows \`Poll N: state=...\` lines and ends with \`Dataform workflow invocation succeeded\`
- [ ] Confirm \"Notify ML Pipeline\" only runs after that
- [ ] Confirm game embeddings run does not hit \`No valid embeddings found in data\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)