### PR TITLE
Add user_collection_predictions Dataform model (v0.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4] - 2026-05-04
+
+### Added
+
+- **`predictions.user_collection_predictions` table**: New incremental Dataform model exposing per-user collection-model predictions to downstream consumers (e.g. bgg-dash-viewer). Joins `bgg-predictive-models.raw.collection_predictions_landing` to `collection_models_registry` filtered to `status = 'active'`, deduped to the latest `score_ts` per `(username, game_id, outcome)`. Two new cross-project source declarations in `definitions/sources.js`.
+
 ## [0.6.3] - 2026-03-31
 
 ### Added

--- a/definitions/sources.js
+++ b/definitions/sources.js
@@ -52,3 +52,15 @@ declare({
   schema: "raw",
   name: "game_coordinates"
 });
+
+declare({
+  database: "bgg-predictive-models",
+  schema: "raw",
+  name: "collection_predictions_landing"
+});
+
+declare({
+  database: "bgg-predictive-models",
+  schema: "raw",
+  name: "collection_models_registry"
+});

--- a/definitions/user_collection_predictions.sqlx
+++ b/definitions/user_collection_predictions.sqlx
@@ -1,0 +1,56 @@
+config {
+  type: "incremental",
+  schema: "predictions",
+  name: "user_collection_predictions",
+  uniqueKey: ["username", "game_id", "outcome"]
+}
+
+WITH active_models AS (
+  SELECT
+    username,
+    outcome,
+    model_version,
+    finalize_through_year,
+    registered_at
+  FROM ${ref("bgg-predictive-models", "raw", "collection_models_registry")}
+  WHERE status = 'active'
+),
+landing_for_active AS (
+  SELECT
+    p.username,
+    p.game_id,
+    p.outcome,
+    p.predicted_prob,
+    p.predicted_label,
+    p.threshold,
+    p.model_name,
+    p.model_version,
+    p.score_ts,
+    p.job_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY p.username, p.game_id, p.outcome
+      ORDER BY p.score_ts DESC, p.job_id DESC
+    ) AS rn
+  FROM ${ref("bgg-predictive-models", "raw", "collection_predictions_landing")} p
+  INNER JOIN active_models a
+    ON  a.username      = p.username
+    AND a.outcome       = p.outcome
+    AND a.model_version = p.model_version
+  WHERE TRUE
+    ${when(incremental(), `AND p.score_ts > (SELECT MAX(score_ts) FROM ${self()})`)}
+)
+SELECT
+  l.username,
+  l.game_id,
+  l.outcome,
+  l.predicted_prob,
+  l.predicted_label,
+  l.threshold,
+  l.model_name,
+  l.model_version,
+  l.score_ts,
+  a.finalize_through_year,
+  a.registered_at
+FROM landing_for_active l
+INNER JOIN active_models a USING (username, outcome, model_version)
+WHERE l.rn = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bgg-data-warehouse"
-version = "0.6.3"
+version = "0.6.4"
 description = "BoardGameGeek Data Warehouse using BigQuery"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "bgg-data-warehouse"
-version = "0.6.1"
+version = "0.6.4"
 source = { virtual = "." }
 dependencies = [
     { name = "db-dtypes" },


### PR DESCRIPTION
## Summary
- New incremental Dataform model `predictions.user_collection_predictions` that joins `bgg-predictive-models.raw.collection_predictions_landing` to `collection_models_registry` (filtered to `status='active'`) and dedupes to the latest `score_ts` per `(username, game_id, outcome)`.
- Two new cross-project source declarations in `definitions/sources.js`.
- Powers the new Collection Models page in bgg-dash-viewer (separate PR).

## Test plan
- [ ] Dataform CI run completes successfully on merge to `main`.
- [ ] `bq show --schema bgg-data-warehouse:predictions.user_collection_predictions` lists the expected columns.
- [ ] Row counts roughly match active-status entries from `collection_models_registry`.
- [ ] `total == distinct(username, game_id, outcome)` confirms dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)