### PR TITLE
Fix fetch_thing_ids: bypass Cloudflare with stealth, run on GitHub Actions

### DIFF
--- a/.github/workflows/fetch_thing_ids.yml
+++ b/.github/workflows/fetch_thing_ids.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Google Cloud Auth
         uses: google-github-actions/auth@v2
         with:
@@ -22,6 +25,16 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          uv sync
+          uv run playwright install --with-deps chromium
 
       - name: Get pre-run counts
         id: before
@@ -33,12 +46,9 @@ jobs:
             "SELECT COUNT(*) as cnt FROM \`bgg-data-warehouse.raw.thing_ids\`" | tail -1)
           echo "total=$TOTAL" >> $GITHUB_OUTPUT
 
-      - name: Execute Fetch Thing IDs Job
+      - name: Fetch Thing IDs
         run: |
-          gcloud run jobs execute bgg-fetch-thing-ids \
-            --project=${GCP_PROJECT_ID} \
-            --region=${GCP_REGION} \
-            --wait
+          uv run python -m src.pipeline.fetch_thing_ids
 
       - name: Write job summary
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "google-auth>=2.40.3",
     "google-cloud-bigquery-datatransfer>=3.20.0",
     "playwright>=1.58.0",
+    "playwright-stealth>=2.0.3",
 ]
 
 [project.optional-dependencies]
@@ -53,3 +54,6 @@ target-version = ["py312"]
 line-length = 100
 target-version = "py312"
 select = ["E", "F", "B", "I", "N", "UP", "PL", "RUF"]
+
+[dependency-groups]
+dev = []

--- a/src/modules/id_fetcher_browser.py
+++ b/src/modules/id_fetcher_browser.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright, Browser, Page
+from playwright_stealth import Stealth
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -169,7 +170,9 @@ class BrowserIDFetcher:
         """
         all_games: dict[int, str] = {}  # game_id -> type (deduped, last-write-wins)
 
-        with sync_playwright() as p:
+        # Stealth evasions (hide navigator.webdriver, patch WebGL/plugins/etc.)
+        # make Cloudflare's managed challenge resolve from flagged egress IPs.
+        with Stealth().use_sync(sync_playwright()) as p:
             logger.info("Launching browser...")
             browser = p.chromium.launch(headless=self.headless)
             context = browser.new_context(user_agent=USER_AGENT)

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pandas-gbq" },
     { name = "playwright" },
+    { name = "playwright-stealth" },
     { name = "plotly" },
     { name = "polars" },
     { name = "pyarrow" },
@@ -100,6 +101,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.1.0" },
     { name = "pandas-gbq", specifier = ">=0.29.1" },
     { name = "playwright", specifier = ">=1.58.0" },
+    { name = "playwright-stealth", specifier = ">=2.0.3" },
     { name = "plotly", specifier = ">=5.18.0" },
     { name = "polars", specifier = ">=1.30.0" },
     { name = "pyarrow", specifier = ">=15.0.0" },
@@ -113,6 +115,9 @@ requires-dist = [
     { name = "xmltodict", specifier = ">=0.13.0" },
 ]
 provides-extras = ["dev", "test"]
+
+[package.metadata.requires-dev]
+dev = []
 
 [[package]]
 name = "black"
@@ -1193,6 +1198,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
     { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
     { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+]
+
+[[package]]
+name = "playwright-stealth"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/db/6ade5d539c7d151b9defc78fafa8b65aa52352617d0e7699b47008bd801f/playwright_stealth-2.0.3.tar.gz", hash = "sha256:1d8e488fbdd8f190f1269ea8cf5d57d14df3a9f1af1001c41ee3588b2aac3133", size = 25751, upload-time = "2026-04-04T02:50:33.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/10/607c409712c02a26c4cb794820514cb7fdaaeac15fb05bed917fb8a354b3/playwright_stealth-2.0.3-py3-none-any.whl", hash = "sha256:1887ade423ab7ff8ae16d363a30a38de0b5817e1e4a29d47b74bf3a0e3dbfcb4", size = 34385, upload-time = "2026-04-04T02:50:35.246Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The daily `Fetch Thing IDs` job started failing ~2026-06-09 with `TimeoutError: Cloudflare challenge did not complete in time`. The job scrapes `boardgamegeek.com/sitemapindex` (Cloudflare-protected) with headless Playwright.

## Root cause

Cloudflare's `managed` challenge strictness scales with **both** IP reputation and browser fingerprint quality:

- From a **residential IP**, even the naive headless browser passes.
- From a **datacenter IP** (GCP us-central1, and Azure/GitHub runners), the naive headless fingerprint never clears the challenge — confirmed by reproducing the identical failure from two independent datacenter providers.

It is not rate-limiting, not a code regression, and not specific to the GCP IP — it's datacenter egress + a bot-like fingerprint.

## Fix

1. **`playwright-stealth`** — wrap Playwright in `Stealth().use_sync(...)` so evasions (hidden `navigator.webdriver`, patched WebGL/plugins/UA client-hints) make the challenge resolve even from a datacenter IP. This is the piece that actually beats the block.
2. **Run the scrape directly on the GitHub Actions runner** instead of delegating to the Cloud Run job — simpler (no container rebuild/deploy), and the existing `google-github-actions/auth` step already exports `GOOGLE_APPLICATION_CREDENTIALS` for the BigQuery client. No Python auth changes.

## Verification

Ran on this branch from a GitHub Actions runner (Azure datacenter IP):

- Cleared Cloudflare, found 24 sitemaps
- Scraped 188,111 games
- Merged 70 new IDs into BigQuery
- All steps green

## Notes / follow-ups

- This is a Cloudflare arms race; the `_wait_for_cloudflare` 30s timeout is the early-warning signal if BGG/Cloudflare tighten again.
- The Cloud Run job `bgg-fetch-thing-ids` is now orphaned for this workflow; left deployed (harmless), can be cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)