### PR TITLE
Home-box scrape: residential-IP fetch_thing_ids via Task Scheduler + repository_dispatch

### DIFF
--- a/.github/workflows/fetch_new_games.yml
+++ b/.github/workflows/fetch_new_games.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["Fetch Thing IDs"]
     types:
       - completed
+  repository_dispatch:
+    types: [thing_ids_fetched]
   workflow_dispatch:
 
 env:
@@ -15,7 +17,7 @@ jobs:
   fetch-new-games:
     name: Fetch and Process New Games
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Google Cloud Auth

--- a/.github/workflows/fetch_thing_ids.yml
+++ b/.github/workflows/fetch_thing_ids.yml
@@ -1,8 +1,9 @@
 name: Fetch Thing IDs
 
 on:
-  schedule:
-    - cron: '0 6 * * *'  # Run daily at 6 AM UTC
+  # Scheduled scraping moved to the residential-IP home box (Cloudflare blocks
+  # datacenter egress). This workflow is now a manual fallback only.
+  # See docs/superpowers/specs/2026-06-18-home-box-scrape-design.md
   workflow_dispatch:
 
 env:

--- a/.github/workflows/scrape_heartbeat.yml
+++ b/.github/workflows/scrape_heartbeat.yml
@@ -1,0 +1,44 @@
+name: Scrape Heartbeat
+
+# The home box is the only scheduled scraper; with fetch_thing_ids' schedule
+# removed there is no daily red-X on failure. This warns if the box hasn't
+# successfully dispatched within the threshold (box offline, scrape error, etc).
+# See docs/superpowers/specs/2026-06-18-home-box-scrape-design.md
+on:
+  schedule:
+    - cron: '0 12 * * *'  # 6h after the box's 06:00 UTC slot
+  workflow_dispatch:
+
+permissions:
+  actions: read
+
+jobs:
+  check-heartbeat:
+    name: Warn if no recent box dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a recent dispatch-triggered Fetch New Games run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          THRESHOLD_HOURS: '26'  # normal age ~6h; a single missed daily run = ~30h, trips cleanly
+        run: |
+          # Most recent "Run Fetch New Games" run triggered by repository_dispatch.
+          LAST=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/fetch_new_games.yml/runs?event=repository_dispatch&per_page=1" \
+            --jq '.workflow_runs[0].created_at // empty')
+
+          if [ -z "$LAST" ]; then
+            echo "::error::No repository_dispatch-triggered Fetch New Games run found at all."
+            exit 1
+          fi
+
+          LAST_EPOCH=$(date -d "$LAST" +%s)
+          NOW_EPOCH=$(date +%s)
+          AGE_HOURS=$(( (NOW_EPOCH - LAST_EPOCH) / 3600 ))
+          echo "Last box dispatch: $LAST (${AGE_HOURS}h ago)"
+
+          if [ "$AGE_HOURS" -gt "$THRESHOLD_HOURS" ]; then
+            echo "::error::No box dispatch in ${AGE_HOURS}h (> ${THRESHOLD_HOURS}h). Check the home box."
+            exit 1
+          fi
+          echo "Heartbeat OK."

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.6.0
+          terraform_version: "1.9.8"
 
       - name: Terraform Init
         run: terraform init

--- a/docs/superpowers/plans/2026-06-18-home-box-scrape.md
+++ b/docs/superpowers/plans/2026-06-18-home-box-scrape.md
@@ -1,0 +1,361 @@
+# Home-Box Scrape Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the Cloudflare-blocked `fetch_thing_ids` scrape off datacenter GitHub runners onto the maintainer's always-on Windows 11 home box (residential IP), driven by Task Scheduler running native `uv run`. On success the box fires a GitHub `repository_dispatch` that resumes the existing downstream chain. No GitHub-controlled code runs on the box (public-repo fork-PR safety).
+
+**Architecture:** Task Scheduler @ 06:00 UTC → PowerShell wrapper → `uv run python -m src.pipeline.fetch_thing_ids` (authenticated with a dedicated least-privilege SA key) → merges into `raw.thing_ids` → on exit 0, `curl POST /repos/.../dispatches {event_type: thing_ids_fetched}`. `fetch_new_games.yml` gains a `repository_dispatch` trigger; `fetch_thing_ids.yml` loses its `schedule:`. A scheduled heartbeat workflow warns if no run lands within the threshold.
+
+**Tech Stack:** Python 3.12 + uv, Playwright/Chromium (stealth), BigQuery, GitHub Actions, Terraform (GCP IAM), Windows Task Scheduler + PowerShell
+
+**Spec:** `docs/superpowers/specs/2026-06-18-home-box-scrape-design.md`
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `terraform/iam.tf` | Add dedicated least-privilege scraper SA + scoped IAM |
+| Modify | `.github/workflows/fetch_new_games.yml:3-18` | Add `repository_dispatch` trigger + extend `if:` guard |
+| Modify | `.github/workflows/fetch_thing_ids.yml:3-6` | Remove `schedule:`, keep `workflow_dispatch` |
+| Create | `.github/workflows/scrape_heartbeat.yml` | Scheduled warning if no recent box dispatch |
+| Create | `scripts/box/run_fetch_thing_ids.ps1` | Box wrapper: scrape → dispatch → log |
+| Create | `scripts/box/README.md` | Box setup runbook (Task Scheduler, secrets, ACLs) |
+| Manual | GCP / GitHub consoles | Export SA key, create fine-grained PAT, place in `credentials/` |
+
+---
+
+### Task 1: Least-privilege service account (Terraform)
+
+**Files:**
+- Modify: `terraform/iam.tf`
+
+- [ ] **Step 1: Add the scoped scraper SA and IAM**
+
+Append to `terraform/iam.tf`:
+
+```hcl
+# Dedicated least-privilege SA for the home-box thing_ids scrape.
+# Scoped to raw-dataset write only so a leaked box key cannot touch
+# GCS / Cloud Run / other datasets, and rotates independently of CI.
+resource "google_service_account" "thing_ids_scraper" {
+  account_id   = "bgg-thing-ids-scraper"
+  display_name = "BGG thing_ids home-box scraper"
+  description  = "Least-privilege SA for the residential-IP fetch_thing_ids scrape"
+  project      = var.project_id
+}
+
+# Run BQ query/load jobs (project-level is the minimum scope for jobUser).
+resource "google_project_iam_member" "thing_ids_scraper_job_user" {
+  project = var.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.thing_ids_scraper.email}"
+}
+
+# BigQuery Storage Read API — IDFetcher.get_existing_ids() uses .to_dataframe().
+resource "google_project_iam_member" "thing_ids_scraper_read_session" {
+  project = var.project_id
+  role    = "roles/bigquery.readSessionUser"
+  member  = "serviceAccount:${google_service_account.thing_ids_scraper.email}"
+}
+
+# Read/write/create tables in the `raw` dataset ONLY (temp table + MERGE).
+resource "google_bigquery_dataset_iam_member" "thing_ids_scraper_raw_editor" {
+  dataset_id = google_bigquery_dataset.bgg_raw.dataset_id
+  project    = var.project_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${google_service_account.thing_ids_scraper.email}"
+}
+```
+
+- [ ] **Step 2: Validate and review the plan**
+
+Run: `cd terraform && terraform init -backend=false && terraform validate`
+Expected: `Success! The configuration is valid.`
+
+Then review intent (requires GCP creds/backend): `terraform plan` — confirm it adds exactly one SA + three IAM bindings and changes nothing else.
+
+- [ ] **Step 3: Apply (maintainer, with GCP credentials)**
+
+Run: `cd terraform && terraform apply`
+Expected: SA `bgg-thing-ids-scraper@bgg-data-warehouse.iam.gserviceaccount.com` created.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add terraform/iam.tf
+git commit -m "feat: add least-privilege SA for home-box thing_ids scrape"
+```
+
+---
+
+### Task 2: GitHub workflow triggers
+
+**Files:**
+- Modify: `.github/workflows/fetch_new_games.yml`
+- Modify: `.github/workflows/fetch_thing_ids.yml`
+
+- [ ] **Step 1: Add `repository_dispatch` to `fetch_new_games.yml`**
+
+Replace the `on:` block (lines 3-8) with:
+
+```yaml
+on:
+  workflow_run:
+    workflows: ["Fetch Thing IDs"]
+    types:
+      - completed
+  repository_dispatch:
+    types: [thing_ids_fetched]
+  workflow_dispatch:
+```
+
+- [ ] **Step 2: Extend the job `if:` guard (line 18)**
+
+Change:
+
+```yaml
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+```
+
+to:
+
+```yaml
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+```
+
+- [ ] **Step 3: Remove the `schedule:` from `fetch_thing_ids.yml`**
+
+Replace the `on:` block (lines 3-6) with:
+
+```yaml
+on:
+  workflow_dispatch:
+```
+
+(Keeps the workflow as a manual fallback; the home box is now the scheduled scraper. No code revert needed — `main` already runs the bundled-Chromium + stealth version.)
+
+- [ ] **Step 4: Validate both workflows**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/fetch_new_games.yml')); yaml.safe_load(open('.github/workflows/fetch_thing_ids.yml')); print('YAML valid')"`
+Expected: `YAML valid`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/fetch_new_games.yml .github/workflows/fetch_thing_ids.yml
+git commit -m "feat: trigger fetch_new_games on repository_dispatch; drop fetch_thing_ids schedule"
+```
+
+---
+
+### Task 3: Heartbeat workflow
+
+> **Approach (decided):** This task uses a **GitHub-API freshness check** — it asks whether a `repository_dispatch`-triggered "Run Fetch New Games" run was *created* within the threshold. Chosen because it needs **no pipeline change** and keeps the scoped SA minimal. It is a clean "did the box dispatch?" signal: the run row is created the moment the dispatch arrives, independent of whether Fetch New Games later succeeds, so downstream failures do **not** false-alarm here (they surface on their own). It catches the failure set we care about — box offline, Task Scheduler didn't fire, scrape exited non-zero (wrapper skips dispatch), or dispatch call failed — all of which produce "no recent dispatch-triggered run". Alternative considered and rejected: a `raw.scrape_heartbeat` marker table (unambiguous, but adds pipeline code + a Terraform table for ~no extra coverage, since the wrapper only dispatches after the scrape's merge succeeds).
+
+**Files:**
+- Create: `.github/workflows/scrape_heartbeat.yml`
+
+- [ ] **Step 1: Create the heartbeat workflow**
+
+Create `.github/workflows/scrape_heartbeat.yml`:
+
+```yaml
+name: Scrape Heartbeat
+
+# The home box is the only scheduled scraper; with fetch_thing_ids' schedule
+# removed there is no daily red-X on failure. This warns if the box hasn't
+# successfully dispatched within the threshold (box offline, scrape error, etc).
+on:
+  schedule:
+    - cron: '0 12 * * *'  # 6h after the box's 06:00 UTC slot
+  workflow_dispatch:
+
+permissions:
+  actions: read
+
+jobs:
+  check-heartbeat:
+    name: Warn if no recent box dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for a recent dispatch-triggered Fetch New Games run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          THRESHOLD_HOURS: '26'  # normal age ~6h; a single missed daily run = ~30h, trips cleanly
+        run: |
+          # Most recent "Run Fetch New Games" run triggered by repository_dispatch.
+          LAST=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/fetch_new_games.yml/runs?event=repository_dispatch&per_page=1" \
+            --jq '.workflow_runs[0].created_at // empty')
+
+          if [ -z "$LAST" ]; then
+            echo "::error::No repository_dispatch-triggered Fetch New Games run found at all."
+            exit 1
+          fi
+
+          LAST_EPOCH=$(date -d "$LAST" +%s)
+          NOW_EPOCH=$(date +%s)
+          AGE_HOURS=$(( (NOW_EPOCH - LAST_EPOCH) / 3600 ))
+          echo "Last box dispatch: $LAST (${AGE_HOURS}h ago)"
+
+          if [ "$AGE_HOURS" -gt "$THRESHOLD_HOURS" ]; then
+            echo "::error::No box dispatch in ${AGE_HOURS}h (> ${THRESHOLD_HOURS}h). Check the home box."
+            exit 1
+          fi
+          echo "Heartbeat OK."
+```
+
+- [ ] **Step 2: Validate YAML**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/scrape_heartbeat.yml')); print('YAML valid')"`
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/scrape_heartbeat.yml
+git commit -m "feat: add scrape heartbeat workflow for home-box monitoring"
+```
+
+---
+
+### Task 4: Box wrapper script
+
+**Files:**
+- Create: `scripts/box/run_fetch_thing_ids.ps1`
+
+- [ ] **Step 1: Write the wrapper**
+
+Create `scripts/box/run_fetch_thing_ids.ps1`:
+
+```powershell
+#Requires -Version 5.1
+# Home-box wrapper for the residential-IP thing_ids scrape.
+# Runs the native scrape, and on success fires a GitHub repository_dispatch.
+# Secrets live in <repo>/credentials/ (gitignored); never logged.
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot   = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$CredDir    = Join-Path $RepoRoot 'credentials'
+$SaKey      = Join-Path $CredDir 'sa-key.json'
+$PatFile    = Join-Path $CredDir 'github-pat.txt'
+$LogDir     = Join-Path $RepoRoot 'logs'
+$LogFile    = Join-Path $LogDir ('fetch_thing_ids_{0:yyyyMMdd}.log' -f (Get-Date))
+$Repo       = 'phenrickson/bgg-data-warehouse'
+
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+function Log($msg) {
+  $line = "{0:u} {1}" -f (Get-Date), $msg
+  $line | Tee-Object -FilePath $LogFile -Append
+}
+
+Set-Location $RepoRoot
+Log "=== Home-box fetch_thing_ids run starting ==="
+
+# Optional: stay current with main (comment out for manual-rebuild discipline).
+git pull --ff-only 2>&1 | Tee-Object -FilePath $LogFile -Append
+
+if (-not (Test-Path $SaKey))  { Log "FATAL: missing $SaKey";  exit 1 }
+if (-not (Test-Path $PatFile)) { Log "FATAL: missing $PatFile"; exit 1 }
+
+# Scoped SA, set for THIS process only (not a global/system env var).
+$env:GOOGLE_APPLICATION_CREDENTIALS = $SaKey
+
+Log "Running scrape..."
+uv run python -m src.pipeline.fetch_thing_ids 2>&1 | Tee-Object -FilePath $LogFile -Append
+$code = $LASTEXITCODE
+
+if ($code -ne 0) {
+  Log "Scrape FAILED (exit $code) - NOT dispatching."
+  exit $code
+}
+
+Log "Scrape OK - firing repository_dispatch..."
+$pat = (Get-Content $PatFile -Raw).Trim()
+$headers = @{
+  Authorization = "Bearer $pat"
+  Accept        = 'application/vnd.github+json'
+  'User-Agent'  = 'bgg-home-box'
+}
+$body = @{ event_type = 'thing_ids_fetched' } | ConvertTo-Json
+Invoke-RestMethod -Method Post -Uri "https://api.github.com/repos/$Repo/dispatches" `
+  -Headers $headers -Body $body
+Log "Dispatch sent. Done."
+```
+
+- [ ] **Step 2: Lint the script parses**
+
+Run: `powershell -NoProfile -Command "[System.Management.Automation.PSParser]::Tokenize((Get-Content -Raw scripts/box/run_fetch_thing_ids.ps1), [ref]$null) > $null; 'parse OK'"`
+Expected: `parse OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/box/run_fetch_thing_ids.ps1
+git commit -m "feat: add home-box wrapper script for fetch_thing_ids + dispatch"
+```
+
+---
+
+### Task 5: Box setup runbook + manual provisioning
+
+**Files:**
+- Create: `scripts/box/README.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Create `scripts/box/README.md` documenting the one-time manual setup:
+
+1. **Toolchain:** confirm `uv --version` works; run `uv sync` and `uv run playwright install chromium` in the repo.
+2. **Secrets** (`<repo>/credentials/`, gitignored by both `credentials/` and `*.json`):
+   - `sa-key.json` — key for `bgg-thing-ids-scraper` SA. Export:
+     `gcloud iam service-accounts keys create credentials/sa-key.json --iam-account=bgg-thing-ids-scraper@bgg-data-warehouse.iam.gserviceaccount.com`
+   - `github-pat.txt` — fine-grained PAT (Task 6), single line.
+   - Lock the dir to your account: `icacls credentials /inheritance:r /grant:r "$env:USERNAME:(OI)(CI)F"`
+3. **Task Scheduler** task:
+   - Trigger: daily at 06:00 **UTC** (Task Scheduler uses local time — convert; confirm the box is awake then, ~22:00 PT / 01:00 ET prior day).
+   - Action: `powershell.exe -NoProfile -ExecutionPolicy Bypass -File <repo>\scripts\box\run_fetch_thing_ids.ps1`
+   - Settings: "Run only when user is logged on", "Wake the computer to run this task"; disable sleep/fast-startup so the box is reachable at the trigger hour.
+4. **Verify:** run the task manually once; confirm new IDs merge and "Run Fetch New Games" starts from the dispatch.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/box/README.md
+git commit -m "docs: add home-box setup runbook"
+```
+
+---
+
+### Task 6: GitHub PAT (manual)
+
+> No code — operator action, recorded here for completeness.
+
+- [ ] **Step 1: Create a fine-grained PAT**
+  - Resource owner: `phenrickson`; repository access: **only** `bgg-data-warehouse`.
+  - Permissions: **Contents: Read and write** + **Metadata: Read** (required by the create-a-repository-dispatch-event endpoint; read-only is insufficient).
+  - Set a sane expiry and a calendar reminder to rotate.
+
+- [ ] **Step 2: Place it on the box**
+  - Save the token as a single line in `<repo>/credentials/github-pat.txt`.
+
+- [ ] **Step 3: Smoke-test the dispatch**
+  - Run `scripts/box/run_fetch_thing_ids.ps1` manually; confirm a `repository_dispatch`-triggered "Run Fetch New Games" appears in the Actions tab.
+
+---
+
+## Sequencing & dependencies
+
+1. **Task 1** (SA) before Task 5 (box needs the key).
+2. **Task 2** (fetch_new_games trigger) before Task 6 smoke-test (dispatch is a no-op without the trigger).
+3. **Task 6** (PAT) before Task 5 Step 4 verify.
+4. **Task 3** (heartbeat) can land anytime, but only becomes meaningful once the box is live and `fetch_thing_ids` schedule is removed (Task 2 Step 3).
+5. Final cutover: confirm one full end-to-end box run (scrape → merge → dispatch → Fetch New Games → Dataform) before relying on the heartbeat.
+
+## Open item to confirm before/at implementation
+
+- **Heartbeat signal** (Task 3 assumption): GitHub-API dispatch-freshness check vs. a `raw.scrape_heartbeat` marker table. Default is the API check (no pipeline change).

--- a/docs/superpowers/specs/2026-06-18-home-box-scrape-design.md
+++ b/docs/superpowers/specs/2026-06-18-home-box-scrape-design.md
@@ -1,0 +1,128 @@
+# Home-box scrape via cron + repository_dispatch
+
+**Status:** Design in progress. Section 1 (architecture) approved. Sections 2–4 are
+drafted from decided answers but NOT yet reviewed/approved — see "Open questions".
+
+**Branch:** `feature/home-box-scrape`
+
+## Problem
+
+`fetch_thing_ids` scrapes `boardgamegeek.com/sitemapindex` (Cloudflare-protected) and
+merges new game IDs into `bgg-data-warehouse.raw.thing_ids`, which feeds the downstream
+chain `Run Fetch New Games → Run Dataform`.
+
+Around 2026-06-09 Cloudflare began serving an unsolvable `managed` challenge to
+**datacenter egress IPs**. Confirmed root cause: challenge strictness is gated primarily
+by IP reputation. The browser-fingerprint ladder was exhausted and did NOT fix it from
+datacenter IPs:
+
+- naive headless Chromium → blocked
+- `playwright-stealth` + Chromium → cleared for ~2 days (06-11/06-12), then re-blocked 06-13+
+- real Google Chrome headed under xvfb → still blocked (proves IP, not fingerprint, is the wall)
+
+From a **residential IP** the scrape works trivially (even a no-browser `curl_cffi` GET
+returns 200). So the fix is residential egress, not more browser cleverness. A home box
+is available to host it.
+
+Constraint: **the repo is public**, so a registered GitHub self-hosted runner is unsafe
+(fork PRs could execute arbitrary code on the home machine). The chosen architecture
+avoids running any GitHub-controlled code on the box.
+
+## Section 1 — Architecture & data flow (APPROVED)
+
+```
+Home box (cron @ 06:00 UTC, residential IP)
+  └─ docker run pipeline-image:
+       • GOOGLE_APPLICATION_CREDENTIALS → mounted SA key
+       • runs: python -m src.pipeline.fetch_thing_ids
+       • stealth + bundled Chromium clears Cloudflare (residential IP)
+       • merges new IDs into bgg-data-warehouse.raw.thing_ids
+  └─ on success: curl GitHub API → repository_dispatch {event_type: thing_ids_fetched}
+        │
+        ▼
+GitHub Actions: Run Fetch New Games  (now also triggers on repository_dispatch)
+        │ workflow_run (unchanged)
+        ▼
+                 Run Dataform
+```
+
+The box is the only scheduled scraper. GitHub executes nothing *on* the box — it only
+*receives* an API call — so the public-repo fork-PR attack surface never touches the home
+machine. The downstream Actions chain is unchanged except for one added trigger.
+
+## Decided parameters
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Architecture | Cron + `repository_dispatch` | No GitHub code runs on the box → eliminates public-repo runner risk |
+| Runtime on box | Docker (reuse `docker/Dockerfile.pipeline`) | Pins Python/Chromium/system-libs → survives host OS drift for years |
+| BigQuery auth | Service-account key file on the box | Works unattended; same identity family as `GCP_SA_KEY_BGG_DW` |
+| Downstream trigger | Add `repository_dispatch` to `fetch_new_games.yml` alongside existing `workflow_run` | Minimal change; chain runs unchanged; only fires on box success |
+| Old GitHub workflow | `fetch_thing_ids.yml`: remove `schedule:`, keep `workflow_dispatch` fallback; revert real-chrome/xvfb experiment to simpler version | Stops daily red noise without deleting work |
+
+## Section 2 — Dispatch handshake (DRAFT, not approved)
+
+- Box, on successful merge, calls:
+  `POST /repos/phenrickson/bgg-data-warehouse/dispatches`
+  with `{"event_type": "thing_ids_fetched"}`.
+- Auth: a GitHub PAT (fine-grained, scoped to this repo, "Contents: read" + the
+  permission required to send dispatches) stored on the box (env/secrets file, not in repo).
+- `fetch_new_games.yml` adds:
+  ```yaml
+  on:
+    workflow_run: { workflows: ["Fetch Thing IDs"], types: [completed] }  # existing
+    repository_dispatch: { types: [thing_ids_fetched] }                   # new
+    workflow_dispatch:                                                     # existing
+  ```
+- The job's `if:` guard must accept the new event (currently gates on
+  `workflow_run.conclusion == 'success'` / `workflow_dispatch`); add
+  `github.event_name == 'repository_dispatch'`.
+
+## Section 3 — Box setup (DRAFT, not approved)
+
+- Install Docker on the home box (OS TBD — see open questions).
+- Build or pull the `docker/Dockerfile.pipeline` image.
+- Place the SA key JSON at a fixed path; mount read-only into the container.
+- Place config: the container needs `config/bigquery.yaml` (baked into the image already
+  via `COPY . .`) — confirm no host config needed.
+- Cron entry (~06:00 UTC) runs a small wrapper script:
+  1. `docker run` the fetch (creds mounted, network access)
+  2. on exit 0, `curl` the `repository_dispatch`
+  3. log output somewhere on the box for debugging
+- Idempotency: the pipeline already dedups via MERGE, so a re-run is safe.
+
+## Section 4 — Old workflow changes (DRAFT, not approved)
+
+- `fetch_thing_ids.yml`: delete the `schedule:` block; keep `workflow_dispatch`.
+- Revert the `BROWSER_CHANNEL=chrome` / xvfb / real-chrome experiment back to the
+  bundled-Chromium + stealth version (the `feature/home-box-scrape` branch is off `main`,
+  which already has stealth; the real-chrome experiment lives only on
+  `fix/cloudflare-real-chrome` and was never merged — confirm no cleanup needed on main).
+
+## Open questions (resolve when resuming)
+
+1. **Box OS/hardware** — what is the home box (Pi / Linux desktop / macOS / always-on
+   server)? Determines Docker install details and cron mechanics. Must be on & online at
+   06:00 UTC.
+2. **PAT scope & storage** — fine-grained vs classic; exact permission needed to send
+   `repository_dispatch`; where on the box the token lives.
+3. **SA identity** — reuse the existing `GCP_SA_KEY_BGG_DW` service account, or mint a new
+   least-privilege SA with only BQ write to the warehouse? (Least-privilege preferred.)
+4. **Failure visibility** — if the box's cron fails (box offline, scrape error), how do we
+   find out? (No GitHub red X anymore since the scheduled workflow is disabled.) Options:
+   box-side alert, a heartbeat, or a GitHub workflow that warns if no dispatch arrived.
+5. **Confirm** Sections 2–4 with the user before writing the implementation plan.
+
+## Out of scope
+
+- Fixing the datacenter Cloudflare block itself (abandoned — IP reputation, not fixable
+  by browser changes).
+- Migrating other workflows off datacenter egress (only `fetch_thing_ids` scrapes the
+  Cloudflare-protected sitemap).
+
+## Verification (manual stop-gap, already working)
+
+Until the box is set up, the maintainer runs the scrape locally from a residential IP:
+`use-personal` → `uv run python -m src.pipeline.fetch_thing_ids`, then manually dispatches
+`Run Fetch New Games`. This is the interim process and validates the residential-IP premise
+(local runs on 06-15 and 06-18 succeeded: 71 and 117 new IDs merged respectively).

--- a/docs/superpowers/specs/2026-06-18-home-box-scrape-design.md
+++ b/docs/superpowers/specs/2026-06-18-home-box-scrape-design.md
@@ -1,7 +1,7 @@
-# Home-box scrape via cron + repository_dispatch
+# Home-box scrape via Task Scheduler + repository_dispatch
 
-**Status:** Design in progress. Section 1 (architecture) approved. Sections 2–4 are
-drafted from decided answers but NOT yet reviewed/approved — see "Open questions".
+**Status:** Design APPROVED. All sections reviewed; open questions resolved (see
+"Resolved decisions"). Ready for an implementation plan.
 
 **Branch:** `feature/home-box-scrape`
 
@@ -22,7 +22,7 @@ datacenter IPs:
 
 From a **residential IP** the scrape works trivially (even a no-browser `curl_cffi` GET
 returns 200). So the fix is residential egress, not more browser cleverness. A home box
-is available to host it.
+(the maintainer's always-on Windows 11 machine) is available to host it.
 
 Constraint: **the repo is public**, so a registered GitHub self-hosted runner is unsafe
 (fork PRs could execute arbitrary code on the home machine). The chosen architecture
@@ -31,13 +31,13 @@ avoids running any GitHub-controlled code on the box.
 ## Section 1 — Architecture & data flow (APPROVED)
 
 ```
-Home box (cron @ 06:00 UTC, residential IP)
-  └─ docker run pipeline-image:
-       • GOOGLE_APPLICATION_CREDENTIALS → mounted SA key
-       • runs: python -m src.pipeline.fetch_thing_ids
+Home box (Windows 11, Task Scheduler @ 06:00 UTC, residential IP)
+  └─ wrapper script:
+       • GOOGLE_APPLICATION_CREDENTIALS → credentials/sa-key.json (scoped SA)
+       • runs: uv run python -m src.pipeline.fetch_thing_ids
        • stealth + bundled Chromium clears Cloudflare (residential IP)
        • merges new IDs into bgg-data-warehouse.raw.thing_ids
-  └─ on success: curl GitHub API → repository_dispatch {event_type: thing_ids_fetched}
+  └─ on exit 0: curl GitHub API → repository_dispatch {event_type: thing_ids_fetched}
         │
         ▼
 GitHub Actions: Run Fetch New Games  (now also triggers on repository_dispatch)
@@ -50,23 +50,28 @@ The box is the only scheduled scraper. GitHub executes nothing *on* the box — 
 *receives* an API call — so the public-repo fork-PR attack surface never touches the home
 machine. The downstream Actions chain is unchanged except for one added trigger.
 
-## Decided parameters
+## Resolved decisions
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Architecture | Cron + `repository_dispatch` | No GitHub code runs on the box → eliminates public-repo runner risk |
-| Runtime on box | Docker (reuse `docker/Dockerfile.pipeline`) | Pins Python/Chromium/system-libs → survives host OS drift for years |
-| BigQuery auth | Service-account key file on the box | Works unattended; same identity family as `GCP_SA_KEY_BGG_DW` |
+| Architecture | Task Scheduler + `repository_dispatch` | No GitHub code runs on the box → eliminates public-repo runner risk |
+| Runtime on box | **Native `uv run`** (not Docker) | Box is a Windows machine the maintainer actively maintains; Docker Desktop needs an interactive session (perpetual login + daemon-must-be-up). Native is simpler, has no daemon dependency, and already proven by the interim manual runs. |
+| BigQuery auth | **Dedicated least-privilege SA key** in `credentials/` | Bounds blast radius if the home-box key leaks (BQ-write to `raw` only — no GCS/Cloud Run/other datasets); rotates independently of CI's `GCP_SA_KEY_BGG_DW`. |
+| Box | Maintainer's always-on Windows 11 desktop | Must be powered on, logged in, and awake at 06:00 UTC (~22:00 PT / 01:00 ET prior day). |
 | Downstream trigger | Add `repository_dispatch` to `fetch_new_games.yml` alongside existing `workflow_run` | Minimal change; chain runs unchanged; only fires on box success |
-| Old GitHub workflow | `fetch_thing_ids.yml`: remove `schedule:`, keep `workflow_dispatch` fallback; revert real-chrome/xvfb experiment to simpler version | Stops daily red noise without deleting work |
+| Old GitHub workflow | `fetch_thing_ids.yml`: remove `schedule:`, keep `workflow_dispatch` fallback | Stops daily red noise without deleting work. (The real-chrome/xvfb experiment lives only on the unmerged `fix/cloudflare-real-chrome` branch — `main` already has the simple stealth version, so no revert needed here.) |
+| Failure visibility | GitHub **heartbeat workflow** | Scheduled workflow warns if `raw.thing_ids` hasn't been written recently — replaces the red-X signal lost when the scheduled scrape is disabled. |
 
-## Section 2 — Dispatch handshake (DRAFT, not approved)
+## Section 2 — Dispatch handshake (APPROVED)
 
 - Box, on successful merge, calls:
   `POST /repos/phenrickson/bgg-data-warehouse/dispatches`
   with `{"event_type": "thing_ids_fetched"}`.
-- Auth: a GitHub PAT (fine-grained, scoped to this repo, "Contents: read" + the
-  permission required to send dispatches) stored on the box (env/secrets file, not in repo).
+- Auth: a **fine-grained GitHub PAT** scoped to this repo with **Contents: write** +
+  **Metadata: read** (the create-a-repository-dispatch-event endpoint requires
+  `contents: write` — read-only is NOT sufficient). Stored on the box at
+  `credentials/github-pat.txt` (gitignored; see Section 3), read by the host wrapper —
+  never injected anywhere GitHub controls.
 - `fetch_new_games.yml` adds:
   ```yaml
   on:
@@ -74,44 +79,85 @@ machine. The downstream Actions chain is unchanged except for one added trigger.
     repository_dispatch: { types: [thing_ids_fetched] }                   # new
     workflow_dispatch:                                                     # existing
   ```
-- The job's `if:` guard must accept the new event (currently gates on
-  `workflow_run.conclusion == 'success'` / `workflow_dispatch`); add
-  `github.event_name == 'repository_dispatch'`.
+- The job's `if:` guard currently gates on
+  `github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'`;
+  add `|| github.event_name == 'repository_dispatch'`.
 
-## Section 3 — Box setup (DRAFT, not approved)
+## Section 3 — Box setup (APPROVED, Windows native)
 
-- Install Docker on the home box (OS TBD — see open questions).
-- Build or pull the `docker/Dockerfile.pipeline` image.
-- Place the SA key JSON at a fixed path; mount read-only into the container.
-- Place config: the container needs `config/bigquery.yaml` (baked into the image already
-  via `COPY . .`) — confirm no host config needed.
-- Cron entry (~06:00 UTC) runs a small wrapper script:
-  1. `docker run` the fetch (creds mounted, network access)
-  2. on exit 0, `curl` the `repository_dispatch`
-  3. log output somewhere on the box for debugging
-- Idempotency: the pipeline already dedups via MERGE, so a re-run is safe.
+The box is a Windows 11 machine; runtime is native `uv run` (no Docker), driven by Task
+Scheduler.
 
-## Section 4 — Old workflow changes (DRAFT, not approved)
+**Secrets** — a gitignored `credentials/` directory at the repo root (already covered by
+`.gitignore`: both `credentials/` and `*.json`). Lock it down with NTFS ACLs to the
+maintainer's account only.
 
-- `fetch_thing_ids.yml`: delete the `schedule:` block; keep `workflow_dispatch`.
-- Revert the `BROWSER_CHANNEL=chrome` / xvfb / real-chrome experiment back to the
-  bundled-Chromium + stealth version (the `feature/home-box-scrape` branch is off `main`,
-  which already has stealth; the real-chrome experiment lives only on
-  `fix/cloudflare-real-chrome` and was never merged — confirm no cleanup needed on main).
+- `credentials/sa-key.json` — the scoped SA key (Section "Least-privilege SA" below).
+  Used by the scrape via `GOOGLE_APPLICATION_CREDENTIALS`.
+- `credentials/github-pat.txt` — the fine-grained PAT (one line). Read by the wrapper for
+  the dispatch call only.
 
-## Open questions (resolve when resuming)
+**Toolchain** — confirm `uv` is installed and `uv run playwright install chromium` has
+provisioned the bundled Chromium on the box. (`config/bigquery.yaml` is already in the
+repo working tree, so no extra config placement is needed.)
 
-1. **Box OS/hardware** — what is the home box (Pi / Linux desktop / macOS / always-on
-   server)? Determines Docker install details and cron mechanics. Must be on & online at
-   06:00 UTC.
-2. **PAT scope & storage** — fine-grained vs classic; exact permission needed to send
-   `repository_dispatch`; where on the box the token lives.
-3. **SA identity** — reuse the existing `GCP_SA_KEY_BGG_DW` service account, or mint a new
-   least-privilege SA with only BQ write to the warehouse? (Least-privilege preferred.)
-4. **Failure visibility** — if the box's cron fails (box offline, scrape error), how do we
-   find out? (No GitHub red X anymore since the scheduled workflow is disabled.) Options:
-   box-side alert, a heartbeat, or a GitHub workflow that warns if no dispatch arrived.
-5. **Confirm** Sections 2–4 with the user before writing the implementation plan.
+**Wrapper script** (PowerShell), run by Task Scheduler ~06:00 UTC:
+
+1. `cd` to the repo; optionally `git pull` to stay current with `main`.
+2. Set `GOOGLE_APPLICATION_CREDENTIALS` to `credentials/sa-key.json` for this process only
+   (not a global/system env var).
+3. `uv run python -m src.pipeline.fetch_thing_ids`.
+4. On exit 0, read the PAT and `curl` the `repository_dispatch`.
+5. Append stdout/stderr to a log file on the box for debugging.
+
+**Task Scheduler config** — trigger at 06:00 UTC; "Run only when user is logged on" (native
+process, no Docker daemon needed); "Wake the computer to run this task"; and Windows
+sleep/fast-startup settings adjusted so the box is reliably awake. The box must stay
+powered on and logged in at that hour.
+
+**Idempotency** — the pipeline dedups via `MERGE`, so a re-run (or a missed-then-catch-up
+run) is safe.
+
+## Least-privilege SA (APPROVED, Terraform)
+
+New Terraform-managed service account, scoped to exactly what the scrape does (read
+existing IDs, load a temp table, `MERGE` into `raw.thing_ids`, delete the temp table):
+
+- `google_service_account` (e.g. `bgg-thing-ids-scraper`).
+- `roles/bigquery.jobUser` at project level — run query/load jobs.
+- `roles/bigquery.readSessionUser` at project level — the code's `.to_dataframe()` uses the
+  BigQuery Storage Read API.
+- `roles/bigquery.dataEditor` scoped to the **`raw` dataset only** via
+  `google_bigquery_dataset_iam_member` referencing `google_bigquery_dataset.bgg_raw` — NOT
+  a project-level grant.
+- A key for the SA, exported and placed at `credentials/sa-key.json` on the box.
+
+A leaked copy of this key can touch only the `raw` dataset and BQ job execution — no GCS,
+no Cloud Run, no other datasets — and is rotatable without affecting CI.
+
+## Section 4 — Old workflow changes (APPROVED)
+
+- `fetch_thing_ids.yml`: delete the `schedule:` block; keep `workflow_dispatch` as a manual
+  fallback.
+- No code revert needed on `main`: the real-chrome/xvfb experiment was never merged (it
+  lives only on `fix/cloudflare-real-chrome`); `main` already runs the bundled-Chromium +
+  stealth version.
+
+## Section 5 — Failure visibility (APPROVED, heartbeat)
+
+With the scheduled scrape disabled, GitHub no longer shows a daily red X on failure. A
+scheduled **heartbeat workflow** replaces that signal:
+
+- Runs on a `schedule:` (e.g. a few hours after the box's 06:00 UTC slot).
+- Queries the freshness of `raw.thing_ids` (e.g. `MAX(load_timestamp)`); if no write has
+  landed within a staleness threshold (e.g. ~36h, allowing for "no new IDs" days — TBD in
+  implementation), the workflow fails so it surfaces as a notification.
+- Uses the existing `GCP_SA_KEY_BGG_DW` (read-only query in CI is fine; the scoped SA is
+  for the box only).
+- Threshold tuning note: "no new IDs found" is a *successful* run that may still write a
+  `load_timestamp`-bearing row only when there ARE new IDs — confirm during implementation
+  whether to heartbeat on table writes or on a dedicated run-marker, so a legitimately
+  empty day doesn't false-alarm.
 
 ## Out of scope
 
@@ -122,7 +168,8 @@ machine. The downstream Actions chain is unchanged except for one added trigger.
 
 ## Verification (manual stop-gap, already working)
 
-Until the box is set up, the maintainer runs the scrape locally from a residential IP:
-`use-personal` → `uv run python -m src.pipeline.fetch_thing_ids`, then manually dispatches
-`Run Fetch New Games`. This is the interim process and validates the residential-IP premise
-(local runs on 06-15 and 06-18 succeeded: 71 and 117 new IDs merged respectively).
+Until the box automation is set up, the maintainer runs the scrape locally from a
+residential IP: `use-personal` → `uv run python -m src.pipeline.fetch_thing_ids`, then
+manually dispatches `Run Fetch New Games`. This is the interim process and validates the
+residential-IP premise (local runs on 06-15 and 06-18 succeeded: 71 and 117 new IDs merged
+respectively).

--- a/scripts/box/README.md
+++ b/scripts/box/README.md
@@ -1,0 +1,72 @@
+# Home-box scrape setup (Windows)
+
+One-time setup to run the residential-IP `fetch_thing_ids` scrape on this box
+via Task Scheduler. Background and rationale:
+`docs/superpowers/specs/2026-06-18-home-box-scrape-design.md`.
+
+The box is the only scheduled scraper. On success it fires a GitHub
+`repository_dispatch` (`thing_ids_fetched`) that resumes the downstream
+`Run Fetch New Games -> Run Dataform` chain. GitHub runs nothing *on* the box.
+
+## 1. Toolchain
+
+- Confirm `uv --version` works.
+- In the repo: `uv sync` then `uv run playwright install chromium`.
+- `config/bigquery.yaml` is already in the repo working tree — no extra config needed.
+
+## 2. Secrets (`<repo>/credentials/`, gitignored)
+
+The `credentials/` directory is ignored by both `credentials/` and `*.json` rules
+in `.gitignore`, so keys placed here can never be committed.
+
+- **SA key** — key for the scoped `bgg-thing-ids-scraper` SA (created by Terraform,
+  applied via the Terraform CI workflow on merge). Export it:
+
+  ```
+  gcloud iam service-accounts keys create credentials/sa-key.json \
+    --iam-account=bgg-thing-ids-scraper@bgg-data-warehouse.iam.gserviceaccount.com
+  ```
+
+- **GitHub PAT** — fine-grained token, single line, at `credentials/github-pat.txt`.
+  Scope: repository access limited to `bgg-data-warehouse`; permissions
+  **Contents: Read and write** + **Metadata: Read** (the create-a-repository-dispatch
+  endpoint requires `contents: write`; read-only is insufficient). Set an expiry and a
+  rotation reminder.
+
+- **Lock down the directory** to your account only:
+
+  ```
+  icacls credentials /inheritance:r /grant:r "$env:USERNAME:(OI)(CI)F"
+  ```
+
+## 3. Task Scheduler
+
+Create a daily task that runs the wrapper:
+
+- **Trigger:** daily at **06:00 UTC**. Task Scheduler uses *local* time — convert
+  accordingly (~22:00 PT / ~01:00 ET the prior day) and confirm the box is awake then.
+- **Action:** start a program:
+
+  ```
+  powershell.exe -NoProfile -ExecutionPolicy Bypass -File <repo>\scripts\box\run_fetch_thing_ids.ps1
+  ```
+
+- **Settings:** "Run only when user is logged on" (native process, no Docker daemon
+  needed); "Wake the computer to run this task"; and disable sleep / fast-startup so the
+  box is reachable at the trigger hour.
+
+## 4. Verify
+
+- Run the task manually once (or run the wrapper directly).
+- Confirm new IDs merge into `bgg-data-warehouse.raw.thing_ids`.
+- Confirm a `repository_dispatch`-triggered **Run Fetch New Games** appears in the GitHub
+  Actions tab, and the downstream chain proceeds.
+- The **Scrape Heartbeat** workflow (`.github/workflows/scrape_heartbeat.yml`) will warn
+  if no dispatch lands within ~26h.
+
+## Notes
+
+- Idempotent: the pipeline dedups via `MERGE`, so a re-run or a missed-then-catch-up run
+  is safe.
+- `fetch_thing_ids.yml` remains as a manual `workflow_dispatch` fallback (its schedule was
+  removed).

--- a/scripts/box/run_fetch_thing_ids.ps1
+++ b/scripts/box/run_fetch_thing_ids.ps1
@@ -1,0 +1,55 @@
+#Requires -Version 5.1
+# Home-box wrapper for the residential-IP thing_ids scrape.
+# Runs the native scrape, and on success fires a GitHub repository_dispatch.
+# Secrets live in <repo>/credentials/ (gitignored); never logged.
+# See docs/superpowers/specs/2026-06-18-home-box-scrape-design.md
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$CredDir  = Join-Path $RepoRoot 'credentials'
+$SaKey    = Join-Path $CredDir 'sa-key.json'
+$PatFile  = Join-Path $CredDir 'github-pat.txt'
+$LogDir   = Join-Path $RepoRoot 'logs'
+$LogFile  = Join-Path $LogDir ('fetch_thing_ids_{0:yyyyMMdd}.log' -f (Get-Date))
+$Repo     = 'phenrickson/bgg-data-warehouse'
+
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+function Log($msg) {
+  $line = "{0:u} {1}" -f (Get-Date), $msg
+  $line | Tee-Object -FilePath $LogFile -Append
+}
+
+Set-Location $RepoRoot
+Log "=== Home-box fetch_thing_ids run starting ==="
+
+# Optional: stay current with main (comment out for manual-rebuild discipline).
+git pull --ff-only 2>&1 | Tee-Object -FilePath $LogFile -Append
+
+if (-not (Test-Path $SaKey))   { Log "FATAL: missing $SaKey";   exit 1 }
+if (-not (Test-Path $PatFile)) { Log "FATAL: missing $PatFile"; exit 1 }
+
+# Scoped SA, set for THIS process only (not a global/system env var).
+$env:GOOGLE_APPLICATION_CREDENTIALS = $SaKey
+
+Log "Running scrape..."
+uv run python -m src.pipeline.fetch_thing_ids 2>&1 | Tee-Object -FilePath $LogFile -Append
+$code = $LASTEXITCODE
+
+if ($code -ne 0) {
+  Log "Scrape FAILED (exit $code) - NOT dispatching."
+  exit $code
+}
+
+Log "Scrape OK - firing repository_dispatch..."
+$pat = (Get-Content $PatFile -Raw).Trim()
+$headers = @{
+  Authorization = "Bearer $pat"
+  Accept        = 'application/vnd.github+json'
+  'User-Agent'  = 'bgg-home-box'
+}
+$body = @{ event_type = 'thing_ids_fetched' } | ConvertTo-Json
+Invoke-RestMethod -Method Post -Uri "https://api.github.com/repos/$Repo/dispatches" `
+  -Headers $headers -Body $body
+Log "Dispatch sent. Done."

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -68,3 +68,43 @@ resource "google_service_account_iam_member" "bgg_pipeline_act_as_self" {
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.bgg_pipeline.email}"
 }
+
+# =============================================================================
+# Home-box thing_ids scraper — dedicated least-privilege service account.
+#
+# The fetch_thing_ids scrape runs on a residential-IP home box (Cloudflare
+# blocks datacenter egress). This SA is scoped to raw-dataset write only, so a
+# leaked box key cannot touch GCS / Cloud Run / other datasets, and it rotates
+# independently of the broad CI key (GCP_SA_KEY_BGG_DW / bgg_pipeline).
+# See docs/superpowers/specs/2026-06-18-home-box-scrape-design.md
+# =============================================================================
+
+resource "google_service_account" "thing_ids_scraper" {
+  account_id   = "bgg-thing-ids-scraper"
+  display_name = "BGG thing_ids home-box scraper"
+  description  = "Least-privilege SA for the residential-IP fetch_thing_ids scrape"
+  project      = var.project_id
+}
+
+# Run BigQuery query/load jobs (jobUser has no narrower scope than project).
+resource "google_project_iam_member" "thing_ids_scraper_job_user" {
+  project = var.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.thing_ids_scraper.email}"
+}
+
+# BigQuery Storage Read API — IDFetcher.get_existing_ids() uses .to_dataframe().
+resource "google_project_iam_member" "thing_ids_scraper_read_session" {
+  project = var.project_id
+  role    = "roles/bigquery.readSessionUser"
+  member  = "serviceAccount:${google_service_account.thing_ids_scraper.email}"
+}
+
+# Read/write/create tables in the `raw` dataset ONLY (temp table + MERGE into
+# thing_ids). Dataset-scoped, NOT a project-level grant.
+resource "google_bigquery_dataset_iam_member" "thing_ids_scraper_raw_editor" {
+  dataset_id = google_bigquery_dataset.bgg_raw.dataset_id
+  project    = var.project_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${google_service_account.thing_ids_scraper.email}"
+}


### PR DESCRIPTION
Moves the Cloudflare-blocked `fetch_thing_ids` scrape off datacenter GitHub runners onto the maintainers always-on Windows home box (residential IP), driven by Task Scheduler running native `uv run`. On success the box fires a GitHub `repository_dispatch` that resumes the existing downstream chain. No GitHub-controlled code runs on the box (public-repo fork-PR safety).

Design + plan: `docs/superpowers/specs/2026-06-18-home-box-scrape-design.md`, `docs/superpowers/plans/2026-06-18-home-box-scrape.md`.

## Changes
- **Terraform** - new least-privilege `bgg-thing-ids-scraper` SA, scoped to raw-dataset write only (`jobUser` + `readSessionUser` at project level, `dataEditor` on the `raw` dataset). Bounds blast radius if the box key leaks; rotates independently of the broad CI key. (Applied by the Terraform CI workflow on merge.)
- **Workflows** - `fetch_new_games.yml` now also triggers on `repository_dispatch {thing_ids_fetched}` (if-guard extended); `fetch_thing_ids.yml` loses its daily `schedule:` and becomes a manual fallback.
- **Heartbeat** - `scrape_heartbeat.yml`: scheduled workflow that warns if no dispatch-triggered Fetch New Games run lands within ~26h (replaces the red-X signal lost when the schedule was removed).
- **Box automation** - `scripts/box/run_fetch_thing_ids.ps1` (scrape then dispatch wrapper) + `scripts/box/README.md` (Windows Task Scheduler / secrets runbook).

## Post-merge manual steps
1. Merge -> Terraform CI applies the scoped SA.
2. Create the fine-grained PAT (Contents: write + Metadata: read), export the SA key; place both in gitignored `credentials/`.
3. Configure the Task Scheduler task per `scripts/box/README.md`.
4. Verify end-to-end (run the wrapper; confirm IDs merge and Fetch New Games fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)