### PR TITLE
fix: home-box wrapper - run native commands via cmd (PS 5.1 stderr abort)

### DIFF
--- a/scripts/box/run_fetch_thing_ids.ps1
+++ b/scripts/box/run_fetch_thing_ids.ps1
@@ -24,8 +24,11 @@ function Log($msg) {
 Set-Location $RepoRoot
 Log "=== Home-box fetch_thing_ids run starting ==="
 
-# Optional: stay current with main (comment out for manual-rebuild discipline).
-git pull --ff-only 2>&1 | Tee-Object -FilePath $LogFile -Append
+# Stay current with main. Run native git via cmd so its stderr (progress
+# output) is redirected to the log without PowerShell's Stop preference
+# treating it as a terminating error.
+Log "Updating repo (git pull --ff-only)..."
+cmd /c "git pull --ff-only >> `"$LogFile`" 2>&1"
 
 if (-not (Test-Path $SaKey))   { Log "FATAL: missing $SaKey";   exit 1 }
 if (-not (Test-Path $PatFile)) { Log "FATAL: missing $PatFile"; exit 1 }
@@ -34,7 +37,11 @@ if (-not (Test-Path $PatFile)) { Log "FATAL: missing $PatFile"; exit 1 }
 $env:GOOGLE_APPLICATION_CREDENTIALS = $SaKey
 
 Log "Running scrape..."
-uv run python -m src.pipeline.fetch_thing_ids 2>&1 | Tee-Object -FilePath $LogFile -Append
+# Run via cmd so the native command's combined output goes cleanly to the log
+# and its exit code is read from $LASTEXITCODE. PowerShell 5.1 mangles native
+# `2>&1` (wraps stderr as ErrorRecords and, under ErrorActionPreference Stop,
+# aborts on the first stderr line - which Python logging emits immediately).
+cmd /c "uv run python -m src.pipeline.fetch_thing_ids >> `"$LogFile`" 2>&1"
 $code = $LASTEXITCODE
 
 if ($code -ne 0) {


### PR DESCRIPTION
The home-box wrapper (`scripts/box/run_fetch_thing_ids.ps1`) aborted before doing any work.

**Cause:** PowerShell 5.1 wraps a native commands stderr as ErrorRecords when piped with `2>&1`, and under `$ErrorActionPreference = Stop` the first stderr line throws a terminating error. The `fetch_thing_ids` scrape writes to stderr immediately (Python logging), so the script died on line 1 of output.

**Fix:** run `git pull` and the scrape via `cmd /c` with redirection to the log file, and read the real result from `$LASTEXITCODE`.

**Verified end-to-end on the box after this fix:**
- Playwright/Chromium clears Cloudflare on the residential IP
- the scoped SA key authenticates to BigQuery (queried existing IDs; "no new IDs" this run)
- the `repository_dispatch` fires and triggers Run Fetch New Games

🤖 Generated with [Claude Code](https://claude.com/claude-code)