### PR TITLE
fix: home-box wrapper log encoding (consistent UTF-8)

### DIFF
--- a/scripts/box/run_fetch_thing_ids.ps1
+++ b/scripts/box/run_fetch_thing_ids.ps1
@@ -18,7 +18,10 @@ New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
 
 function Log($msg) {
   $line = "{0:u} {1}" -f (Get-Date), $msg
-  $line | Tee-Object -FilePath $LogFile -Append
+  Write-Host $line
+  # Append as UTF-8 (no BOM) so PS log lines match the cmd/Python output below
+  # (PS 5.1 Tee-Object/Out-File default to UTF-16, which mojibakes the file).
+  [System.IO.File]::AppendAllText($LogFile, $line + [Environment]::NewLine, (New-Object System.Text.UTF8Encoding $false))
 }
 
 Set-Location $RepoRoot
@@ -28,7 +31,7 @@ Log "=== Home-box fetch_thing_ids run starting ==="
 # output) is redirected to the log without PowerShell's Stop preference
 # treating it as a terminating error.
 Log "Updating repo (git pull --ff-only)..."
-cmd /c "git pull --ff-only >> `"$LogFile`" 2>&1"
+cmd /c "chcp 65001 >nul & git pull --ff-only >> `"$LogFile`" 2>&1"
 
 if (-not (Test-Path $SaKey))   { Log "FATAL: missing $SaKey";   exit 1 }
 if (-not (Test-Path $PatFile)) { Log "FATAL: missing $PatFile"; exit 1 }
@@ -36,12 +39,15 @@ if (-not (Test-Path $PatFile)) { Log "FATAL: missing $PatFile"; exit 1 }
 # Scoped SA, set for THIS process only (not a global/system env var).
 $env:GOOGLE_APPLICATION_CREDENTIALS = $SaKey
 
+# Force UTF-8 from Python so its log output matches the log file's encoding.
+$env:PYTHONUTF8 = '1'
+
 Log "Running scrape..."
 # Run via cmd so the native command's combined output goes cleanly to the log
 # and its exit code is read from $LASTEXITCODE. PowerShell 5.1 mangles native
 # `2>&1` (wraps stderr as ErrorRecords and, under ErrorActionPreference Stop,
 # aborts on the first stderr line - which Python logging emits immediately).
-cmd /c "uv run python -m src.pipeline.fetch_thing_ids >> `"$LogFile`" 2>&1"
+cmd /c "chcp 65001 >nul & uv run python -m src.pipeline.fetch_thing_ids >> `"$LogFile`" 2>&1"
 $code = $LASTEXITCODE
 
 if ($code -ne 0) {


### PR DESCRIPTION
The home-box wrapper log (`logs/fetch_thing_ids_*.log`) came out partially garbled: PowerShell 5.1 `Tee-Object` writes UTF-16 while the `cmd /c` redirections wrote OEM-codepage bytes, so the mixed file mojibaked.

**Fix:**
- PS log lines written as UTF-8 (no BOM) via `[System.IO.File]::AppendAllText` (replacing `Tee-Object`), plus `Write-Host` for live console.
- `chcp 65001` on the `cmd /c` redirections.
- `PYTHONUTF8=1` so the scrapes output matches.

**Verified on the box:** the full scrape log now renders cleanly end-to-end (all 24 sitemaps, 188,417 games found vs 188,900 in BigQuery, no new IDs, dispatch sent, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)