### PR TITLE
feat: harden home-box scrape against mid-run standby and index blips

### DIFF
--- a/scripts/box/run_fetch_thing_ids.ps1
+++ b/scripts/box/run_fetch_thing_ids.ps1
@@ -24,45 +24,68 @@ function Log($msg) {
   [System.IO.File]::AppendAllText($LogFile, $line + [Environment]::NewLine, (New-Object System.Text.UTF8Encoding $false))
 }
 
+# --- Keep the box awake for the whole run -----------------------------------
+# The mini PC uses Modern Standby; if it drops into low-power idle mid-scrape
+# the NIC sleeps and the fetch dies with a network error (this starved the
+# 2026-07-14/15 runs). Assert a system-required lock for the duration so the
+# run can't be starved even if the global power plan is later reset to sleep.
+# Disable-StayAwake in the finally clears it so normal idle-sleep resumes; the
+# lock is also released automatically when this process exits.
+Add-Type -Namespace Win32 -Name Power -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true)]
+public static extern uint SetThreadExecutionState(uint esFlags);
+'@
+$ES_CONTINUOUS      = [uint32]2147483648  # 0x80000000
+$ES_SYSTEM_REQUIRED = [uint32]1           # 0x00000001
+function Enable-StayAwake  { [void][Win32.Power]::SetThreadExecutionState([uint32]($ES_CONTINUOUS -bor $ES_SYSTEM_REQUIRED)) }
+function Disable-StayAwake { [void][Win32.Power]::SetThreadExecutionState($ES_CONTINUOUS) }
+
 Set-Location $RepoRoot
 Log "=== Home-box fetch_thing_ids run starting ==="
+Enable-StayAwake
+Log "Wake-lock asserted (box will stay awake until this run completes)."
 
-# Stay current with main. Run native git via cmd so its stderr (progress
-# output) is redirected to the log without PowerShell's Stop preference
-# treating it as a terminating error.
-Log "Updating repo (git pull --ff-only)..."
-cmd /c "chcp 65001 >nul & git pull --ff-only >> `"$LogFile`" 2>&1"
+try {
+  # Stay current with main. Run native git via cmd so its stderr (progress
+  # output) is redirected to the log without PowerShell's Stop preference
+  # treating it as a terminating error.
+  Log "Updating repo (git pull --ff-only)..."
+  cmd /c "chcp 65001 >nul & git pull --ff-only >> `"$LogFile`" 2>&1"
 
-if (-not (Test-Path $SaKey))   { Log "FATAL: missing $SaKey";   exit 1 }
-if (-not (Test-Path $PatFile)) { Log "FATAL: missing $PatFile"; exit 1 }
+  if (-not (Test-Path $SaKey))   { Log "FATAL: missing $SaKey";   exit 1 }
+  if (-not (Test-Path $PatFile)) { Log "FATAL: missing $PatFile"; exit 1 }
 
-# Scoped SA, set for THIS process only (not a global/system env var).
-$env:GOOGLE_APPLICATION_CREDENTIALS = $SaKey
+  # Scoped SA, set for THIS process only (not a global/system env var).
+  $env:GOOGLE_APPLICATION_CREDENTIALS = $SaKey
 
-# Force UTF-8 from Python so its log output matches the log file's encoding.
-$env:PYTHONUTF8 = '1'
+  # Force UTF-8 from Python so its log output matches the log file's encoding.
+  $env:PYTHONUTF8 = '1'
 
-Log "Running scrape..."
-# Run via cmd so the native command's combined output goes cleanly to the log
-# and its exit code is read from $LASTEXITCODE. PowerShell 5.1 mangles native
-# `2>&1` (wraps stderr as ErrorRecords and, under ErrorActionPreference Stop,
-# aborts on the first stderr line - which Python logging emits immediately).
-cmd /c "chcp 65001 >nul & uv run python -m src.pipeline.fetch_thing_ids >> `"$LogFile`" 2>&1"
-$code = $LASTEXITCODE
+  Log "Running scrape..."
+  # Run via cmd so the native command's combined output goes cleanly to the log
+  # and its exit code is read from $LASTEXITCODE. PowerShell 5.1 mangles native
+  # `2>&1` (wraps stderr as ErrorRecords and, under ErrorActionPreference Stop,
+  # aborts on the first stderr line - which Python logging emits immediately).
+  cmd /c "chcp 65001 >nul & uv run python -m src.pipeline.fetch_thing_ids >> `"$LogFile`" 2>&1"
+  $code = $LASTEXITCODE
 
-if ($code -ne 0) {
-  Log "Scrape FAILED (exit $code) - NOT dispatching."
-  exit $code
+  if ($code -ne 0) {
+    Log "Scrape FAILED (exit $code) - NOT dispatching."
+    exit $code
+  }
+
+  Log "Scrape OK - firing repository_dispatch..."
+  $pat = (Get-Content $PatFile -Raw).Trim()
+  $headers = @{
+    Authorization = "Bearer $pat"
+    Accept        = 'application/vnd.github+json'
+    'User-Agent'  = 'bgg-home-box'
+  }
+  $body = @{ event_type = 'thing_ids_fetched' } | ConvertTo-Json
+  Invoke-RestMethod -Method Post -Uri "https://api.github.com/repos/$Repo/dispatches" `
+    -Headers $headers -Body $body
+  Log "Dispatch sent. Done."
 }
-
-Log "Scrape OK - firing repository_dispatch..."
-$pat = (Get-Content $PatFile -Raw).Trim()
-$headers = @{
-  Authorization = "Bearer $pat"
-  Accept        = 'application/vnd.github+json'
-  'User-Agent'  = 'bgg-home-box'
+finally {
+  Disable-StayAwake
 }
-$body = @{ event_type = 'thing_ids_fetched' } | ConvertTo-Json
-Invoke-RestMethod -Method Post -Uri "https://api.github.com/repos/$Repo/dispatches" `
-  -Headers $headers -Body $body
-Log "Dispatch sent. Done."

--- a/src/modules/id_fetcher_browser.py
+++ b/src/modules/id_fetcher_browser.py
@@ -86,7 +86,11 @@ class BrowserIDFetcher:
     def fetch_sitemap_index(self, page: Page) -> list[str]:
         """Fetch and parse the sitemap index to get individual sitemap URLs.
 
-        Uses the browser to bypass Cloudflare on the index page.
+        Uses the browser to bypass Cloudflare on the index page. This is the
+        first and most critical navigation of the run - if it fails, nothing
+        downstream can proceed - so it retries with exponential backoff just
+        like fetch_sitemap_page rather than letting a single transient blip
+        (a network hiccup or a Cloudflare interstitial) kill the whole scrape.
 
         Args:
             page: Playwright page object
@@ -94,23 +98,51 @@ class BrowserIDFetcher:
         Returns:
             List of sitemap URLs for board games, sorted by type
         """
-        logger.info(f"Fetching sitemap index: {self.SITEMAP_INDEX_URL}")
-        page.goto(self.SITEMAP_INDEX_URL)
-        self._wait_for_cloudflare(page)
+        last_error = None
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                logger.info(f"Fetching sitemap index: {self.SITEMAP_INDEX_URL}")
+                # wait_until="domcontentloaded" (not the default "load"): we only
+                # need the parsed HTML to regex out sitemap URLs. Waiting for
+                # every subresource to finish can hang indefinitely behind a
+                # Cloudflare challenge - that "load"-timeout is what stalled the
+                # 2026-07-14/15 runs.
+                page.goto(self.SITEMAP_INDEX_URL, wait_until="domcontentloaded")
+                self._wait_for_cloudflare(page)
 
-        content = page.content()
+                content = page.content()
 
-        full_urls = []
-        for match in re.finditer(self.SITEMAP_PATTERN, content):
-            full_urls.append(match.group(0))
+                full_urls = []
+                for match in re.finditer(self.SITEMAP_PATTERN, content):
+                    full_urls.append(match.group(0))
 
-        # Sort: boardgame sitemaps first, then expansion, then accessory
-        full_urls.sort(key=self._sitemap_sort_key)
+                # A 200 with no sitemap URLs means we got a block/challenge page
+                # rather than the real index - treat it as a retryable failure.
+                if not full_urls:
+                    raise RuntimeError(
+                        "No sitemap URLs found on index page "
+                        "(possible Cloudflare block or empty response)"
+                    )
 
-        logger.info(f"Found {len(full_urls)} board game sitemaps")
-        for url in full_urls:
-            logger.info(f"  {url}")
-        return full_urls
+                # Sort: boardgame sitemaps first, then expansion, then accessory
+                full_urls.sort(key=self._sitemap_sort_key)
+
+                logger.info(f"Found {len(full_urls)} board game sitemaps")
+                for url in full_urls:
+                    logger.info(f"  {url}")
+                return full_urls
+
+            except Exception as e:
+                last_error = e
+                if attempt < self.MAX_RETRIES - 1:
+                    wait = self.RETRY_BACKOFF_BASE * (2 ** attempt)
+                    logger.warning(
+                        f"Error fetching sitemap index: {e}, "
+                        f"retrying in {wait}s (attempt {attempt + 1}/{self.MAX_RETRIES})"
+                    )
+                    time.sleep(wait)
+
+        raise last_error
 
     def fetch_sitemap_page(self, page: Page, url: str) -> list[dict]:
         """Fetch a single sitemap page via browser and extract game IDs.

--- a/tests/test_id_fetcher_browser.py
+++ b/tests/test_id_fetcher_browser.py
@@ -1,0 +1,89 @@
+"""Tests for the browser-based BGG ID fetcher.
+
+Focus: the retry/backoff hardening on fetch_sitemap_index (the first and most
+critical navigation of the scrape). See id_fetcher_browser.py.
+"""
+
+from unittest import mock
+
+import pytest
+
+from src.modules.id_fetcher_browser import BrowserIDFetcher
+
+SITEMAP_INDEX_HTML = """
+<html><body>
+https://boardgamegeek.com/sitemap_geekitems_boardgame_1
+https://boardgamegeek.com/sitemap_geekitems_boardgame_2
+https://boardgamegeek.com/sitemap_geekitems_boardgameexpansion_1
+https://boardgamegeek.com/sitemap_geekitems_boardgameaccessory_1
+</body></html>
+"""
+
+
+def _make_page(goto_side_effect, content=SITEMAP_INDEX_HTML):
+    """Build a fake Playwright page with a scripted goto()."""
+    page = mock.Mock()
+    page.goto.side_effect = goto_side_effect
+    page.title.return_value = ""  # no Cloudflare interstitial -> _wait returns at once
+    page.content.return_value = content
+    return page
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    """Skip the real exponential-backoff waits so tests run instantly."""
+    with mock.patch("src.modules.id_fetcher_browser.time.sleep"):
+        yield
+
+
+def test_fetch_sitemap_index_success_first_try():
+    fetcher = BrowserIDFetcher()
+    page = _make_page(goto_side_effect=[None])
+
+    urls = fetcher.fetch_sitemap_index(page)
+
+    assert len(urls) == 4
+    # boardgame sorts before expansion before accessory (last-write-wins typing)
+    assert urls[0].endswith("boardgame_1")
+    assert urls[-1].endswith("boardgameaccessory_1")
+    assert page.goto.call_count == 1
+
+
+def test_fetch_sitemap_index_retries_then_succeeds():
+    fetcher = BrowserIDFetcher()
+    # Fail the first two navigations (network blips), succeed on the third.
+    page = _make_page(
+        goto_side_effect=[
+            RuntimeError("net::ERR_INTERNET_DISCONNECTED"),
+            RuntimeError("Timeout 30000ms exceeded"),
+            None,
+        ]
+    )
+
+    urls = fetcher.fetch_sitemap_index(page)
+
+    assert len(urls) == 4
+    assert page.goto.call_count == 3
+
+
+def test_fetch_sitemap_index_raises_after_max_retries():
+    fetcher = BrowserIDFetcher()
+    err = RuntimeError("net::ERR_NAME_NOT_RESOLVED")
+    page = _make_page(goto_side_effect=[err, err, err])
+
+    with pytest.raises(RuntimeError, match="ERR_NAME_NOT_RESOLVED"):
+        fetcher.fetch_sitemap_index(page)
+
+    assert page.goto.call_count == BrowserIDFetcher.MAX_RETRIES
+
+
+def test_fetch_sitemap_index_empty_content_is_retryable():
+    fetcher = BrowserIDFetcher()
+    # goto() "succeeds" but the page has no sitemap URLs (a block/challenge
+    # page) - this must be treated as a retryable failure, not a silent 0.
+    page = _make_page(goto_side_effect=[None, None, None], content="<html>blocked</html>")
+
+    with pytest.raises(RuntimeError, match="No sitemap URLs"):
+        fetcher.fetch_sitemap_index(page)
+
+    assert page.goto.call_count == BrowserIDFetcher.MAX_RETRIES


### PR DESCRIPTION
## Why

The residential-IP `fetch_thing_ids` scrape on the home mini PC stopped dispatching on **2026-07-14 and 07-15**, tripping the Scrape Heartbeat.

Root cause was **not** Cloudflare or the IP — the scrape works fine on demand. The mini PC uses **Modern Standby (S0 low-power idle)** with a 5-minute AC sleep timeout. `WakeToRun` wakes the box to *start* the job, but with no user present it fell back into connected standby ~5 min later, which killed the NIC mid-scrape. The browser navigation then died with `ERR_INTERNET_DISCONNECTED` / `ERR_NAME_NOT_RESOLVED` / a `load`-event timeout (hence the multi-hour gaps in the logs). Successful days finished in ~80s and beat the sleep timer — that's why it was intermittent (also failed Jun 20, Jun 29), until two consecutive misses tripped the 26h heartbeat.

The machine-level fix (`powercfg /change standby-timeout-ac 0`) is already applied on the box. This PR makes the scrape **self-defending** so a future power-config reset can't silently reintroduce the failure, and hardens the most fragile navigation.

## Changes

- **`scripts/box/run_fetch_thing_ids.ps1`** — assert a `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)` wake-lock for the run's duration so the box can't sleep mid-scrape regardless of the global power plan; released in a `finally` (and by process exit).
- **`src/modules/id_fetcher_browser.py`** — `fetch_sitemap_index()` was the only unguarded navigation (and the most critical — everything downstream depends on it). Added the same 3× exponential-backoff retry `fetch_sitemap_page()` already uses, switched `wait_until` to `"domcontentloaded"` (we only need the HTML to regex sitemap URLs; waiting for full `load` is what hung behind Cloudflare), and made a URL-less page a retryable block instead of a silent empty result.
- **`tests/test_id_fetcher_browser.py`** — new coverage for the retry/backoff paths (first-try success, retry-then-succeed, raise-after-max-retries, empty-content-is-retryable).

## Testing

- `pytest tests/test_id_fetcher_browser.py` → 4 passed.
- Verified the modified `fetch_sitemap_index()` against live BGG with the real stealth browser: 24 sitemaps, correctly sorted.
- Parse-checked the PowerShell wrapper and confirmed the wake-lock API call succeeds on the box.

The wake-lock's real effect is only observable at the next unattended scheduled run (Windows power API), so it's smoke-tested here rather than fully exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)