### PR TITLE
feat: add Claude skills (.claude/skills/)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,55 @@
+# Claude skills
+
+Project-scoped [Claude Code](https://claude.com/claude-code) skills for this repo.
+Each skill is a structured workflow Claude can follow, lightly tailored to this
+project's stack (uv pipelines, BigQuery `raw`/`core`/`predictions`/`analytics`,
+Dataform models in `definitions/`, the GitHub Actions `repository_dispatch` chain,
+and the residential-IP home-box scrape).
+
+## Using them
+
+- Invoke explicitly with a slash command: `/debugging`, `/dataform-model`, …
+- Or just describe your task — Claude auto-selects a skill when its `description` matches.
+- New skills are picked up when Claude Code loads `.claude/skills/`; reload the window
+  if a freshly added one doesn't appear.
+
+## Available skills
+
+### Generic workflow helpers
+
+| Skill | Use it when |
+|-------|-------------|
+| [`brainstorming`](brainstorming/SKILL.md) | Weighing options — diverge into distinct approaches, then converge on a recommendation |
+| [`planning`](planning/SKILL.md) | A non-trivial change — produce an ordered, verifiable plan with risks/rollback before coding |
+| [`debugging`](debugging/SKILL.md) | Something's broken — evidence-first root-cause method (reproduce, timeline, isolate, verify) |
+| [`write-tests`](write-tests/SKILL.md) | Adding/extending pytest with BigQuery + Playwright mocked; reproducing a bug as a failing test |
+| [`explain-codebase`](explain-codebase/SKILL.md) | Onboarding or "where does X happen" — grounded, file-cited walkthroughs |
+| [`data-exploration`](data-exploration/SKILL.md) | Ad-hoc BigQuery — dry-run-first, cost-aware, read-only by default |
+
+### Repo-specific workflows
+
+| Skill | Use it when |
+|-------|-------------|
+| [`dataform-model`](dataform-model/SKILL.md) | Adding/modifying a Dataform model — source decl, config/incremental, `ref()` wiring, validation |
+| [`release`](release/SKILL.md) | Cutting a release — SemVer bump + Keep-a-Changelog entry → auto-tag via the Tag Release workflow |
+
+> Built-in Claude Code skills (`/code-review`, `/simplify`, `/verify`, `/run`, …) are
+> intentionally not duplicated here.
+
+## Adding a skill
+
+Create `.claude/skills/<name>/SKILL.md` with YAML frontmatter:
+
+```markdown
+---
+name: <kebab-case-name>            # must match the directory
+description: <what it does and, crucially, WHEN to use it — this drives auto-selection>
+---
+
+# <Title>
+
+<the workflow: steps, repo-specific gotchas, commands to run>
+```
+
+Keep it focused, ground repo-specific claims in real files/paths, and add a row to the
+table above.

--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: brainstorming
+description: Explore options and generate ideas before committing to an approach. Use when the user wants to weigh alternatives, asks "what are my options / how could we approach X", or is at the start of a fuzzy problem and needs divergent thinking before converging on a plan. Not for tasks where the approach is already clear.
+---
+
+# Brainstorming
+
+Help the user think broadly before narrowing. The goal is to surface genuinely
+different approaches and their trade-offs, then land on a recommendation — not to
+start implementing.
+
+## Process
+
+1. **Frame the problem.** Restate the goal in one sentence and name the hard
+   constraints (cost, time, data volume, Cloudflare/rate limits, what must not
+   break). If the request is underspecified, ask 1–3 targeted questions before
+   diverging — don't brainstorm against a guess.
+
+2. **Diverge.** Generate 3–5 *distinct* approaches, not variations of one idea.
+   Push past the obvious first answer. Include at least one "cheap/boring" option
+   and one "what if we rethought this" option. For each:
+   - How it works (2–4 sentences)
+   - Pros / cons
+   - Rough effort and risk
+   - How well it fits this repo's grain (see below)
+
+3. **Converge.** Compare the options against the constraints. Recommend one (or a
+   hybrid), and say plainly *why* it wins and what you'd give up.
+
+4. **Name the unknowns.** What would you need to validate before committing —
+   a spike, a cost estimate, a sample query, a question for the user? Hand off to
+   `planning` once an approach is chosen.
+
+## Keep it honest
+
+- Don't inflate the count with near-duplicates. Three real options beat five fake ones.
+- Surface the option you'd *not* pursue and why — the discarded ideas are part of the value.
+- Flag anything that's a one-way door (schema migrations, backfills, deleting data,
+  changing table partitioning, public-facing outputs).
+
+## This repo (context to weigh options against)
+
+- **Python pipelines** run as `uv run python -m src.pipeline.<name>`; logic in `src/`.
+- **Data** lives in BigQuery — `raw.*` tables land raw data; **Dataform** models in
+  `definitions/` transform it. BigQuery cost (bytes scanned) is a real constraint.
+- **Orchestration** is GitHub Actions in `.github/workflows/`; the pipeline chain is
+  stitched together with `repository_dispatch` events.
+- **Scraping** BGG runs from a residential-IP **home box** because Cloudflare blocks
+  datacenter egress — approaches that need heavy scraping must account for that.
+- Favor **idempotent** designs (the ID pipeline dedups via `MERGE`) and incremental
+  Dataform models over full rebuilds.

--- a/.claude/skills/data-exploration/SKILL.md
+++ b/.claude/skills/data-exploration/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: data-exploration
+description: Answer questions about the warehouse data with safe, cost-aware BigQuery. Use when the user wants to inspect table contents, check row counts/freshness/nulls, profile a column, validate a pipeline's output, or write an ad-hoc analytical query. Emphasizes dry-run-first and cost control.
+---
+
+# Data exploration
+
+Query the BigQuery warehouse to answer data questions — cost-consciously. The project
+is `bgg-data-warehouse` (location `US`). Datasets: `raw` (landed data, e.g.
+`raw.thing_ids`), `core`, `predictions`, `analytics` (Dataform outputs).
+
+## Rules of engagement
+
+1. **Dry-run first on anything non-trivial.** Know what it scans before you run it:
+   ```
+   bq query --dry-run --nouse_legacy_sql '<SQL>'
+   ```
+   It reports bytes scanned without spending. For a big table, that number is the cost.
+
+2. **Never `SELECT *` on a large table.** Select only the columns you need; the fewer
+   columns, the fewer bytes scanned (BigQuery is columnar).
+
+3. **Prune with the partition/cluster keys**, and `LIMIT` while exploring — note that
+   `LIMIT` does **not** reduce bytes scanned (only column and partition pruning does).
+
+4. **Start small, then widen.** Peek at schema and a few rows before aggregating:
+   ```
+   bq show --schema --format=prettyjson bgg-data-warehouse:raw.thing_ids
+   bq query --nouse_legacy_sql 'SELECT * FROM `bgg-data-warehouse.raw.thing_ids` LIMIT 20'
+   ```
+
+## Common questions → queries
+
+- **Row counts by type:**
+  `SELECT type, COUNT(*) c FROM \`bgg-data-warehouse.raw.thing_ids\` GROUP BY type ORDER BY type`
+- **Freshness / did the last run land data:** `SELECT MAX(load_timestamp) FROM ...`
+  (the ID pipeline stamps `load_timestamp`; predictions models stamp `score_ts`).
+- **Unprocessed backlog:** `... WHERE processed = false`.
+- **Null/quality check:** `SELECT COUNTIF(col IS NULL) nulls, COUNT(*) total FROM ...`.
+- **Dedup sanity (grain):** `SELECT key, COUNT(*) c FROM ... GROUP BY key HAVING c > 1`.
+
+## Guardrails
+
+- Read-only by default. **Do not** run `CREATE`/`DELETE`/`UPDATE`/`MERGE`/`TRUNCATE`
+  against warehouse tables from an exploration — data changes go through pipelines and
+  Dataform, not ad-hoc SQL. Confirm explicitly before any mutating statement.
+- Prefer backtick-quoted `\`project.dataset.table\`` and `--nouse_legacy_sql`.
+- If a query would scan many GB, say so and confirm before running it.

--- a/.claude/skills/dataform-model/SKILL.md
+++ b/.claude/skills/dataform-model/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: dataform-model
+description: Add or modify a Dataform model in definitions/ correctly. Use when creating a new transformation/table/view, exposing a new source table, or changing an existing .sqlx model. Covers source declaration, config, ref() wiring, incremental patterns, and validation before merge.
+---
+
+# Dataform model
+
+Add or change a Dataform model without breaking compilation, dependency lineage,
+or incremental state. Models live in `definitions/*.sqlx`; project config is in
+`workflow_settings.yaml` (defaultProject `bgg-data-warehouse`, defaultDataset
+`analytics`, location `US`, dataformCore 3.0.0). Execution happens via the
+**Run Dataform** GitHub Actions workflow, chained after fetches by `repository_dispatch`.
+
+## Steps
+
+1. **Understand the data.** Know the grain (one row per what?), the source table(s),
+   and the target schema/dataset. Read a couple of existing `.sqlx` files first to
+   match style — e.g. `bgg_complexity_predictions.sqlx`.
+
+2. **Declare any new source.** Anything you `ref()` must be declared in
+   `definitions/sources.js`. Same-project: `declare({ schema, name })`. Cross-project
+   (e.g. `bgg-predictive-models`): `declare({ database, schema, name })`.
+
+3. **Write the config block.** Choose the type deliberately:
+   - `view` — cheap, always fresh, no storage; for light reshaping.
+   - `table` — full rebuild each run; for small/derived outputs.
+   - `incremental` — appends/merges only new rows; for large or append-only sources.
+     Set `uniqueKey: [...]` and guard the source scan with
+     `${when(incremental(), \`AND score_ts > (SELECT MAX(score_ts) FROM ${self()})\`)}`.
+   ```
+   config {
+     type: "incremental",
+     schema: "predictions",
+     name: "my_model",
+     uniqueKey: ["game_id"]
+   }
+   ```
+
+4. **Wire dependencies via `ref()`** — never hard-code fully-qualified table names.
+   `${ref("core", "games")}` or cross-project `${ref("bgg-predictive-models", "raw", "complexity_predictions")}`. This is what builds the lineage graph and the correct run order.
+
+5. **Dedup to the grain.** The house pattern is `ROW_NUMBER() OVER (PARTITION BY <key>
+   ORDER BY score_ts DESC, job_id DESC)` then `WHERE rn = 1` — keep the latest row per key.
+
+6. **Validate before merge.** Compile to catch ref/syntax errors
+   (`npx @dataform/cli compile`, or rely on the Run Dataform workflow's compile step).
+   Sanity-check the SQL against BigQuery with a dry-run (see the `bigquery-cost-check`
+   skill) so you know what it scans.
+
+## Watch out for
+
+- **Incremental correctness:** a wrong or missing `uniqueKey`/incremental guard causes
+  duplicates or silently drops rows. When in doubt, a full-refresh `table` is safer.
+- **New source not declared** → compile fails. Add it to `sources.js` in the same PR.
+- **Downstream lineage:** changing a model's columns can break models that `ref()` it —
+  grep `definitions/` for dependents.
+- Assertions (data tests) land in the `analytics_assertions` dataset.

--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: debugging
+description: Systematically find the root cause of a failure before fixing it. Use when something is broken — a failing GitHub Actions workflow, a pipeline error, an unexpected/empty BigQuery result, a failing test, or the home-box scrape not running. Emphasizes evidence and reproduction over guessing.
+---
+
+# Debugging
+
+Find the *root cause* with evidence, then fix it — don't pattern-match to a
+plausible-sounding fix and move on. Distinguish the symptom from the cause.
+
+## Process (scientific method)
+
+1. **Reproduce and observe.** Get the exact error text, the failing command, and
+   the conditions. Read the actual logs — never infer the error from the
+   description alone.
+
+2. **Establish a timeline.** When did it last work vs. first fail? Correlate with
+   what changed (a merge, a dependency bump, an upstream/BGG change, a schedule).
+   `git log`, the run history, and dated logs are your friends here.
+
+3. **Form ranked hypotheses.** List the plausible causes most-likely first, and for
+   each note *what evidence would confirm or refute it*. Prefer the hypothesis that
+   explains **all** the observations (e.g. a multi-hour gap between start and error
+   is not a 30s timeout — it's a freeze/suspend).
+
+4. **Isolate.** Reduce to the smallest reproduction. Binary-search the surface:
+   which file, which step, which record, which commit (`git bisect` when useful).
+
+5. **Confirm the root cause** before changing anything. Can you explain the full
+   causal chain? Can you reproduce and then *un*-reproduce it on demand?
+
+6. **Fix, then verify.** Re-run and confirm the failure is actually gone — check
+   real output, not just "no exception." State what you observed.
+
+7. **Prevent regression.** Add a test or guard if the bug could recur, and check
+   the fix didn't break an adjacent path.
+
+## This repo — where to look
+
+- **Pipeline logs:** `logs/*.log` (dated). The home-box scrape writes
+  `logs/fetch_thing_ids_YYYYMMDD.log`. Note these stamps are **local time** despite a
+  trailing `Z`.
+- **CI:** `gh run list` and `gh run view <id> --log-failed` for GitHub Actions.
+  The daily chain is `Fetch Thing IDs → Fetch New Games → Dataform`, wired via
+  `repository_dispatch`; a missing dispatch shows up in the **Scrape Heartbeat** run.
+- **Data:** `bq query --nouse_legacy_sql '<SQL>'` to inspect `raw.*` and warehouse
+  tables. Check row counts / freshness before assuming code is wrong.
+- **Run a pipeline locally:** `uv run python -m src.pipeline.<name>`.
+- **Tests:** `uv run --extra test python -m pytest tests/ -q`.
+
+## Repo-specific gotchas
+
+- **Scrape failures are often environmental, not code:** Cloudflare challenges,
+  the home box sleeping/offline (Modern Standby), or a residential-IP block — confirm
+  the scrape works on demand before touching the scraper.
+- **Partial sitemap fetches misclassify types** — the pipeline intentionally fails
+  the whole run rather than upload partial results.
+- On Windows PowerShell, native-command stderr is *not* an error; don't treat a
+  non-empty stderr as failure — check the exit code.

--- a/.claude/skills/explain-codebase/SKILL.md
+++ b/.claude/skills/explain-codebase/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: explain-codebase
+description: Explain how part of this repo works and how the pieces fit together. Use when onboarding, answering "where does X happen / how does the data flow / what calls this", or building a mental model before making a change. Read-first; grounds every claim in actual files.
+---
+
+# Explain codebase
+
+Give an accurate, grounded explanation of how something works here — trace the real
+code and data flow, cite concrete files, and don't guess. Read before you explain.
+
+## How to explain
+
+1. **Find the entry point**, then follow the calls. Cite `path:line` so the user can
+   click through. If a claim isn't backed by a file you read, don't make it.
+
+2. **Situate it in the pipeline.** Most things here are a stage in the daily flow:
+   **scrape IDs → fetch game data → land in BigQuery `raw` → Dataform transforms →
+   models/predictions**. Say where the piece sits and what triggers it.
+
+3. **Name the boundary it crosses** — a BigQuery table, a BGG HTTP call, a
+   `repository_dispatch` event, a cross-project Dataform source. That's usually where
+   the interesting behavior (and the bugs) live.
+
+4. **Match depth to the question.** "Where does X happen" → point to the file/function.
+   "How does the whole thing work" → a short flow with the key hops, not a file dump.
+
+## Map of the repo
+
+- **`src/pipeline/`** — orchestration entry points, run as `uv run python -m src.pipeline.<name>`
+  (e.g. `fetch_thing_ids`, `fetch_new_games`, `fetch_games`).
+- **`src/modules/`, `src/id_fetcher/`, `src/api_client/`, `src/data_processor/`,
+  `src/warehouse/`** — the building blocks: BGG scraping/ID discovery, the BGG API
+  client, response processing, and BigQuery load/merge logic.
+- **`definitions/*.sqlx` + `sources.js`** — Dataform: SQL transformations and source
+  declarations. Config in `workflow_settings.yaml`.
+- **`.github/workflows/`** — orchestration. The chain `Fetch Thing IDs → Fetch New Games
+  → Run Dataform` is stitched with `repository_dispatch`; `Scrape Heartbeat` watches it.
+- **`scripts/box/`** — the residential-IP home-box scrape wrapper (Cloudflare blocks
+  datacenter egress) and its setup docs.
+- **`config/`** — `bigquery.yaml` (project/datasets, refresh policy), `cloudbuild.yaml`.
+- **`docs/architecture/diagrams/`** — architecture and lineage diagrams; good for the
+  big picture.
+
+## Reminders
+
+- Prefer `Grep`/`Glob` to locate things over assuming a path.
+- The BigQuery datasets are `raw` (landed), `core`, `predictions`, `analytics` (Dataform).
+- Timestamps in `logs/` are local time despite the trailing `Z`.

--- a/.claude/skills/planning/SKILL.md
+++ b/.claude/skills/planning/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: planning
+description: Turn a non-trivial task into a concrete, sequenced implementation plan before writing code. Use when the user asks to "plan" or "how should we implement X", or before any change that touches multiple files, the BigQuery schema, Dataform models, or the pipeline/CI chain. Produces an ordered, verifiable plan for approval.
+---
+
+# Planning
+
+Produce a plan the user can approve before implementation starts. A good plan is
+**ordered, verifiable, and honest about risk** — each step should be something you
+can check, not a vague intention.
+
+## Process
+
+1. **Understand first.** Restate the goal and its success criteria. **Read the
+   relevant code before planning** — don't plan against assumptions. Note what
+   already exists that you can reuse.
+
+2. **Scope.** State what's in and what's explicitly out. Identify every affected
+   surface: `src/` pipeline code, `definitions/` Dataform models, BigQuery schemas,
+   `.github/workflows/`, config, tests, docs.
+
+3. **Sequence the work.** Break it into ordered steps, each independently
+   verifiable, smallest-safe-change first. Call out dependencies and anything that
+   must land in a specific order (e.g. create a table before the model that reads it).
+
+4. **Surface risks and unknowns.** What could break or is irreversible —
+   schema/partitioning changes, **backfills**, BigQuery cost, Cloudflare/rate limits,
+   scheduling, cross-project Dataform sources? Note the rollback story and any open
+   questions to resolve before starting.
+
+5. **Define verification.** For each step, how do you prove it works — a unit test,
+   a Dataform dry-run/`--dry-run`, a manual `uv run` of the pipeline, a `bq query`
+   sanity check, or a workflow run.
+
+6. **Present for approval.** Show the plan and stop for a go-ahead before writing
+   code. For anything sizeable, prefer using plan mode (`EnterPlanMode` /
+   `ExitPlanMode`) so the plan is reviewed explicitly.
+
+## Output shape
+
+- **Goal & success criteria** — 1–2 lines
+- **Affected files/systems** — the concrete list
+- **Steps** — numbered, each with its verification
+- **Risks / unknowns / rollback** — what to watch, what's one-way
+- **Out of scope** — what you're deliberately not doing
+
+## This repo (shape plans to fit it)
+
+- Changes ship via **PRs to `main`**; keep each PR focused on one concern.
+- Pipelines run as `uv run python -m src.pipeline.<name>`; tests via
+  `uv run --extra test python -m pytest`.
+- The daily flow is `Fetch Thing IDs → Fetch New Games → Dataform`, chained by
+  `repository_dispatch` — a change to one stage often has downstream effects.
+- Prefer **incremental** Dataform models and **idempotent** pipeline steps
+  (`MERGE`-based upserts) so a re-run or catch-up is always safe.
+- New raw data usually means: land in `raw.*` → declare a source in
+  `definitions/sources.js` → add/adjust a Dataform model → wire any trigger.
+- Watch BigQuery cost (bytes scanned) and whether a change requires a **backfill**
+  of historical data.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: release
+description: Cut a release the way this repo does it. Use when the user wants to publish a new version, bump the version, or update the changelog for a release. Covers the CHANGELOG entry, the SemVer bump, and the automatic tagging flow.
+---
+
+# Release
+
+This repo releases by **bumping the version in `pyproject.toml`**. On push to `main`
+touching that file, the **Tag Release** workflow (`.github/workflows/tag-release.yml`)
+auto-creates and pushes a `vX.Y.Z` git tag. There is no manual `git tag` step.
+
+## Steps
+
+1. **Decide the bump (SemVer).** Look at what's landed since the last release:
+   - `patch` (0.6.4 → 0.6.5): bug fixes, ops hardening, no behavior change for consumers.
+   - `minor` (0.6.4 → 0.7.0): new tables/models/pipelines/workflows, backward-compatible.
+   - `major` (0.6.4 → 1.0.0): breaking changes to schemas or published outputs.
+
+2. **Update `CHANGELOG.md`.** Follow Keep a Changelog. Add a new
+   `## [X.Y.Z] - YYYY-MM-DD` section above the previous one, grouped under
+   `### Added` / `### Fixed` / `### Changed` etc. Write entries for *consumers* of the
+   warehouse, not commit-by-commit. Review `git log <last-tag>..HEAD` to gather them.
+
+3. **Bump `version` in `pyproject.toml`** to match the CHANGELOG heading exactly.
+
+4. **PR → merge to `main`.** Keep the bump + changelog in one PR. On merge, Tag Release
+   fires and creates `vX.Y.Z`. Confirm the tag appears (`git tag -l` / the Actions run).
+
+## Checklist
+
+- [ ] CHANGELOG version and date match the `pyproject.toml` version
+- [ ] Entries are consumer-facing and grouped by change type
+- [ ] Bump type matches the actual scope of changes (don't ship a feature as a patch)
+- [ ] No unrelated changes in the release PR
+
+## Notes
+
+- The tag is created **only if** the version string actually changed vs. the previous
+  commit — re-running with the same version is a no-op.
+- Recent small ops fixes (e.g. the home-box PRs) shipped without a version bump; reserve
+  a release for a meaningful, consumer-relevant set of changes.

--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: write-tests
+description: Write or extend pytest tests for this repo. Use when adding tests for new or existing pipeline/module code, reproducing a bug as a failing test, or improving coverage. Favors fast, deterministic unit tests that mock external services (BigQuery, Playwright/BGG).
+---
+
+# Write tests
+
+Add tests that are fast, deterministic, and actually pin down behavior. Tests live
+in `tests/`, run with `uv run --extra test python -m pytest`, and config is in
+`pyproject.toml` (`[tool.pytest.ini_options]`, `pythonpath = ["src"]`).
+
+## Approach
+
+1. **Pin the behavior, not the implementation.** Test observable inputs → outputs and
+   edge cases (empty input, errors, duplicates, boundary values), not private details.
+
+2. **Mock the outside world.** These tests must not hit BigQuery, BGG, or launch a real
+   browser:
+   - **BigQuery:** patch the client / its `query`, `load_table_from_dataframe`,
+     `delete_table` — see `tests/test_id_fetcher.py` for the established pattern
+     (`mock.patch.object(fetcher.client, ...)`).
+   - **Playwright/BGG:** pass a fake `page` (a `mock.Mock` with scripted `goto`,
+     `title`, `content`) — see `tests/test_id_fetcher_browser.py`.
+   - **Backoff/sleep:** patch `time.sleep` (autouse fixture) so retry tests run instantly.
+
+3. **Cover the failure paths.** This codebase deliberately fails loudly (partial sitemap
+   fetches abort; the index fetch retries then raises). Assert those: that it retries N
+   times, that it raises after `MAX_RETRIES`, that a block page is treated as retryable.
+
+4. **Reproduce bugs first.** For a bug fix, write the failing test that captures it,
+   watch it fail, then fix — so the test proves the fix and guards against regression.
+
+## Conventions
+
+- File `tests/test_<module>.py`, functions `test_<behavior>`; import with the `src.`
+  prefix (e.g. `from src.modules.id_fetcher_browser import BrowserIDFetcher`).
+- Use fixtures for shared setup; keep each test focused on one behavior.
+- Mark anything that needs real credentials/network with `@pytest.mark.integration`
+  (declared in `pyproject.toml`) so it can be deselected: `-m "not integration"`.
+
+## Run
+
+- Just your file: `uv run --extra test python -m pytest tests/test_x.py -q`
+- Fast unit suite: `uv run --extra test python -m pytest -m "not integration" -q`


### PR DESCRIPTION
## What

Adds eight project-scoped Claude Code skills under `.claude/skills/`, each tailored to this repo's stack (uv pipelines, BigQuery `raw`/`core`/`predictions`/`analytics`, Dataform models in `definitions/`, the GitHub Actions `repository_dispatch` chain, and the residential-IP home-box scrape). Tooling only — no code paths change.

### Generic workflow skills
| Skill | When it fires |
|-------|---------------|
| **brainstorming** | Weighing options — diverge into distinct approaches, converge on a recommendation |
| **debugging** | Something's broken — evidence-first root-cause method (reproduce, timeline, isolate, verify) |
| **planning** | Non-trivial change — ordered, verifiable plan with risks/rollback before coding |
| **write-tests** | Add/extend pytest with BigQuery + Playwright mocked; reproduce bugs as failing tests |
| **explain-codebase** | Onboarding / "where does X happen" — grounded, file-cited walkthroughs |
| **data-exploration** | Ad-hoc BigQuery — dry-run-first, cost-aware, read-only by default |

### Repo-specific workflow skills
| Skill | When it fires |
|-------|---------------|
| **dataform-model** | Add/modify a Dataform model — source decl, config/incremental, `ref()` wiring, validation |
| **release** | SemVer bump + Keep-a-Changelog entry → auto-tag via the Tag Release workflow |

Invoked as `/brainstorming`, `/dataform-model`, etc., or auto-selected by description.

## Notes

- Repo-specific references were verified against the actual tree (`definitions/`, `sources.js`, `workflow_settings.yaml`, `tag-release.yml`, `config/bigquery.yaml`, the workflow chain, `uv`/pytest invocations).
- Built-ins like `/code-review`, `/simplify`, `/verify` are intentionally not duplicated.
- Kept separate from the home-box hardening PR (#79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)