### PR TITLE
chore: release 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5] - 2026-07-15
+
+### Changed
+
+- **Scheduled ID scraping moved to a residential-IP "home box"**: BGG's Cloudflare protection blocks datacenter egress, so `fetch_thing_ids` no longer runs on a schedule in GitHub Actions. A residential-IP box runs the scrape via Task Scheduler and, on success, fires a `repository_dispatch` (`thing_ids_fetched`) that resumes the downstream `Fetch New Games → Run Dataform` chain. `fetch_thing_ids.yml` remains as a manual `workflow_dispatch` fallback. (#75, #76)
+- **Scrape Heartbeat workflow**: warns if no successful home-box dispatch lands within ~26h (box offline, scrape error, etc.), replacing the daily red-X that the removed schedule used to provide. (#76)
+
+### Fixed
+
+- **Cloudflare bot detection on sitemaps**: fetch the sitemap index and pages through a stealth browser session instead of plain HTTP. (#75)
+- **Home-box wrapper reliability**: run native commands via `cmd` so PowerShell 5.1 doesn't treat native stderr as a terminating error (#77); write the run log as consistent UTF-8 (#78).
+- **Scrape starved by Modern Standby**: the home mini PC was dropping into low-power standby mid-run, killing network connectivity and failing the fetch. The wrapper now holds a `SetThreadExecutionState` wake-lock for the duration of the run, and `fetch_sitemap_index` retries with exponential backoff and uses `wait_until="domcontentloaded"` instead of hanging on `load`. (#79)
+
+### Added
+
+- **Claude Code skills** under `.claude/skills/` (developer tooling, no runtime change): `brainstorming`, `planning`, `debugging`, `write-tests`, `explain-codebase`, `data-exploration`, `dataform-model`, `release`. (#80)
+
 ## [0.6.4] - 2026-05-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bgg-data-warehouse"
-version = "0.6.4"
+version = "0.6.5"
 description = "BoardGameGeek Data Warehouse using BigQuery"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## What

Catches the changelog up and bumps the version — nothing since **0.6.4** (May 4) had been recorded, including the entire home-box scrape migration.

`version` → **0.6.5** in `pyproject.toml`; on merge the **Tag Release** workflow auto-creates `v0.6.5`.

## Why patch, not minor

Everything since 0.6.4 is internal scraping infrastructure, reliability fixes, and developer tooling. No change to the warehouse schema or the data that downstream consumers read → SemVer patch.

## CHANGELOG entry (0.6.5)

- **Changed** — scheduled ID scraping moved to the residential-IP home box via Task Scheduler + `repository_dispatch`; added the Scrape Heartbeat workflow (#75, #76)
- **Fixed** — Cloudflare stealth-browser sitemap fetch (#75); home-box wrapper `cmd`/stderr + UTF-8 log fixes (#77, #78); Modern Standby wake-lock + sitemap-index retry/`domcontentloaded` hardening (#79)
- **Added** — Claude Code skills under `.claude/skills/`, tooling only (#80)

## Note

Going forward the `release` skill (added in #80) documents this exact flow, so the changelog/bump won't get skipped next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)