### PR TITLE
fix(dataform): don't false-fail on slow invocations; gate ML notify on SUCCEEDED

### DIFF
--- a/.github/workflows/dataform.yml
+++ b/.github/workflows/dataform.yml
@@ -67,6 +67,7 @@ jobs:
           echo "compilation_name=${COMPILATION_NAME}" >> $GITHUB_OUTPUT
 
       - name: Execute Workflow
+        id: execute
         run: |
           ACCESS_TOKEN=$(gcloud auth print-access-token)
           API_BASE="https://dataform.googleapis.com/v1beta1/projects/${GCP_PROJECT_ID}/locations/${GCP_REGION}/repositories/${DATAFORM_REPO}"
@@ -86,9 +87,22 @@ jobs:
 
           # Poll until terminal state. The workflowInvocations POST returns
           # immediately with state=RUNNING; downstream consumers (e.g. game
-          # embeddings) read tables this workflow refreshes, so we MUST wait
-          # for SUCCEEDED before letting the job exit.
-          for i in $(seq 1 90); do
+          # embeddings) read tables this workflow refreshes, so the ML pipeline
+          # is only notified once we observe a genuine SUCCEEDED (see the
+          # Notify step's `if`, which keys off invocation_state below).
+          #
+          # Outcomes:
+          #   SUCCEEDED         -> record state, job green, ML notified
+          #   FAILED/CANCELLED  -> hard-fail the job (real error)
+          #   still RUNNING at
+          #   the poll budget   -> record state=RUNNING, job stays GREEN (no
+          #                        false failure), but ML is NOT notified. A
+          #                        slow-but-succeeding invocation used to mark
+          #                        the whole job failed and silently skip the
+          #                        ML dispatch; this avoids that.
+          MAX_POLLS=240   # 240 * 10s = 40 min budget; normal runs finish in <1 min
+          FINAL_STATE="RUNNING"
+          for i in $(seq 1 ${MAX_POLLS}); do
             sleep 10
             ACCESS_TOKEN=$(gcloud auth print-access-token)
             STATUS=$(curl -s "https://dataform.googleapis.com/v1beta1/${INVOCATION_NAME}" \
@@ -96,27 +110,32 @@ jobs:
             echo "Poll $i: state=${STATUS}"
             case "${STATUS}" in
               SUCCEEDED)
+                FINAL_STATE="SUCCEEDED"
                 echo "Dataform workflow invocation succeeded"
-                exit 0
+                break
                 ;;
               FAILED|CANCELLED)
+                echo "invocation_state=${STATUS}" >> "$GITHUB_OUTPUT"
                 echo "Dataform workflow invocation ended with state=${STATUS}"
                 exit 1
                 ;;
               RUNNING|CANCELING)
                 ;;
               *)
+                echo "invocation_state=${STATUS}" >> "$GITHUB_OUTPUT"
                 echo "Unexpected state: ${STATUS}"
                 exit 1
                 ;;
             esac
           done
 
-          echo "Timed out waiting for Dataform workflow invocation to finish"
-          exit 1
+          echo "invocation_state=${FINAL_STATE}" >> "$GITHUB_OUTPUT"
+          if [ "${FINAL_STATE}" != "SUCCEEDED" ]; then
+            echo "::warning::Dataform invocation still ${FINAL_STATE} after ${MAX_POLLS} polls (${INVOCATION_NAME}). Not failing the job; the ML pipeline will not be notified for this run."
+          fi
 
       - name: Notify ML Pipeline
-        if: success() && github.ref == 'refs/heads/main'
+        if: steps.execute.outputs.invocation_state == 'SUCCEEDED' && github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
         run: |


### PR DESCRIPTION
## Problem

The **Run Dataform** workflow has failed every day since **2026-07-14**, always at the *Execute Workflow* step. It was **not** a SQL error — the step polled the Dataform invocation for only ~16 min (`seq 1 90` × 10s) then `exit 1`.

Investigation showed the invocation itself was **not failing**: on 2026-07-16 it ran ~3h and reached `SUCCEEDED`. Two consequences:
1. Red X every day even though Dataform completed.
2. *Notify ML Pipeline* is gated on `success()`, so the `repository_dispatch` to **bgg-predictive-models never fired** — the downstream ML pipeline wasn't being triggered.

## Root cause (fixed separately, out of band)

The ~3h stalls were an artifact of **schema drift** on two incremental models — `games_features` (watermark `load_timestamp`) and `game_similarity_search` (watermark `created_ts`). Dataform never `ALTER`s an existing incremental table, so after the output schema changed the watermark columns stopped being written, the incremental filters misbehaved, and the invocation sat non-terminal for hours (the entire 3h window had ~2s of actual BigQuery compute). Both tables were **full-refreshed via the Dataform API** — watermark columns are back, tables are current, and a scoped refresh now completes in ~20s.

## This PR — harden the workflow so the symptom can't recur

- Raise poll budget **15m → 40m** (normal runs finish in <1 min).
- A still-`RUNNING` invocation at the deadline is now a **soft** outcome (`::warning::`, job stays green) instead of a hard failure.
- Genuine `FAILED`/`CANCELLED` still hard-fails.
- Record the invocation's final state and gate **Notify ML Pipeline** on an actual `SUCCEEDED`, so a slow run no longer silently skips the dispatch and never fires on incomplete data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)