### PR TITLE
feat(api): gate bgg-warehouse-api via authoritative Terraform invoker binding

### DIFF
--- a/terraform/warehouse_api.tf
+++ b/terraform/warehouse_api.tf
@@ -1,0 +1,32 @@
+# Gating for the warehouse read API (bgg-warehouse-api Cloud Run service).
+#
+# The service itself is deployed by the Cloud Build Actions workflow
+# (config/cloudbuild.warehouse-api.yaml). Terraform owns ONLY its inbound invoker IAM,
+# as an AUTHORITATIVE binding so `allUsers` can never be (re)added out of band — the
+# whole point of the gating. Applied by .github/workflows/terraform.yml.
+#
+# ORDERING: this binding targets an existing service, so it must be applied AFTER the
+# service is first deployed (merge the deploy PR before merging this one).
+#
+# See docs/superpowers/specs/2026-07-16-service-auth-pattern-design.md
+
+variable "warehouse_api_invoker_members" {
+  description = <<-EOT
+    Principals granted roles/run.invoker on bgg-warehouse-api (AUTHORITATIVE — this is
+    the complete allow-list; anything not here, including allUsers, cannot invoke).
+    Consumer-agnostic: prefer adding a new consumer's SA to the invoker Google Group
+    rather than listing it here. Add the group once it exists in Workspace, e.g.
+    "group:bgg-api-invokers@googlegroups.com".
+  EOT
+  type    = list(string)
+  default = ["user:phil.henrickson@gmail.com"]
+}
+
+resource "google_cloud_run_v2_service_iam_binding" "warehouse_api_invokers" {
+  project  = var.project_id
+  location = var.region
+  name     = "bgg-warehouse-api"
+  role     = "roles/run.invoker"
+
+  members = var.warehouse_api_invoker_members
+}

--- a/terraform/warehouse_api.tf
+++ b/terraform/warehouse_api.tf
@@ -14,9 +14,13 @@ variable "warehouse_api_invoker_members" {
   description = <<-EOT
     Principals granted roles/run.invoker on bgg-warehouse-api (AUTHORITATIVE — this is
     the complete allow-list; anything not here, including allUsers, cannot invoke).
-    Consumer-agnostic: prefer adding a new consumer's SA to the invoker Google Group
-    rather than listing it here. Add the group once it exists in Workspace, e.g.
-    "group:bgg-api-invokers@googlegroups.com".
+
+    This list IS the grant surface: to give a consumer access, add its identity here and
+    merge (terraform.yml applies it) — grants stay in code, reviewed, and git-audited.
+      - a person:  "user:someone@example.com"
+      - a service: "serviceAccount:new-frontend@bgg-data-warehouse.iam.gserviceaccount.com"
+    (A "group:..." member is possible too, but a group's membership is managed outside
+    Terraform/Actions — prefer listing identities directly here.)
   EOT
   type    = list(string)
   default = ["user:phil.henrickson@gmail.com"]


### PR DESCRIPTION
## What this is

Gating for `bgg-warehouse-api`: an **authoritative** `google_cloud_run_v2_service_iam_binding`
on `roles/run.invoker`. Authoritative ⇒ the `members` list is the complete allow-list,
so `allUsers` can never be (re)added out of band, and drift is corrected on every apply.

Grant surface = the Terraform `members` list (day-one member: the owner). Adding a
consumer later = add its `serviceAccount:` here, PR, merge — grants stay in code and
git-audited.

## ⚠️ Merge order

**Merge the service PR first**, confirm `bgg-warehouse-api` deployed, *then* merge this.
An IAM binding against a not-yet-created service plans fine but **fails at apply**.

## Review gate

On merge, `terraform.yml` runs `plan` then `apply -auto-approve`. **Read the `terraform
plan` in this PR's checks before merging** — it should show **only** the one
`run.invoker` binding being added. If it shows other changes (state drift), do not merge
until reconciled.

See `docs/superpowers/specs/2026-07-16-service-auth-pattern-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
