### PR TITLE
ci(terraform): plan PRs against prod so previews are faithful

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - 'terraform/**'
+      - '.github/workflows/terraform.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'terraform/**'
+      - '.github/workflows/terraform.yml'
   workflow_dispatch:
     inputs:
       action:
@@ -24,7 +26,7 @@ on:
       environment:
         description: 'Environment'
         required: true
-        default: 'dev'
+        default: 'prod'
         type: choice
         options:
           - dev
@@ -71,8 +73,12 @@ jobs:
             echo "action=${{ github.event.inputs.action }}" >> $GITHUB_OUTPUT
             echo "environment=${{ github.event.inputs.environment }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            # Plan with the SAME environment a merge will apply (prod), so the PR plan
+            # is a faithful preview. Planning with dev produced ~30 phantom diffs
+            # (labels + deletion_protection are var.environment-conditional), which
+            # trained reviewers to ignore plans — and would hide real drift.
             echo "action=plan" >> $GITHUB_OUTPUT
-            echo "environment=dev" >> $GITHUB_OUTPUT
+            echo "environment=prod" >> $GITHUB_OUTPUT
           else
             echo "action=apply" >> $GITHUB_OUTPUT
             echo "environment=prod" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

PR terraform plans are **not** faithful previews of what a merge applies.

`Determine Action` planned `pull_request` with `environment=dev`, while a merge applies
with `environment=prod`. Because `labels.environment = var.environment` and
`deletion_protection = var.environment == "prod"` (see `terraform/bigquery.tf`), every
PR plan showed ~**30 phantom changes** — 3 dataset label flips (`prod -> dev`) and 27
tables `deletion_protection = true -> false` — none of which a prod merge would make.

That's not cosmetic: it trains reviewers to wave past terraform plans, which is exactly
how genuine drift eventually gets merged unnoticed. It surfaced while reviewing #87,
where the plan looked alarming but was entirely an artifact.

## Changes

1. **`pull_request` now plans with `environment=prod`** — the same var a merge applies,
   so the PR plan is a real preview.
2. **`workflow_dispatch` default environment `dev` → `prod`.** *Safety fix:* previously
   a dispatch of `action=apply` with the default env would have applied **`dev`** —
   relabelling all datasets and **stripping `deletion_protection` from 27 production
   tables**. The default now matches the only environment actually in use.
3. **`.github/workflows/terraform.yml` added to the trigger paths**, so changes to the
   workflow itself are validated (and this PR self-demonstrates the fix).

## Verification

This PR should now run `Terraform / plan` against `prod` and report **no changes** —
proving the phantom diff is gone. After merge, re-running #87's checks should show a
clean `1 to add, 0 to change` for the invoker binding.

Apply behaviour on merge to `main` is unchanged (`action=apply`, `environment=prod`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
