### PR TITLE
perf(api): run game block queries concurrently

### DIFF
--- a/docs/superpowers/plans/2026-07-21-warehouse-api-reader-perf.md
+++ b/docs/superpowers/plans/2026-07-21-warehouse-api-reader-perf.md
@@ -1,0 +1,128 @@
+# Warehouse API — Reader Latency Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut the wall-clock latency of `GET /games/{id}` with **code-only** changes —
+no Dataform, no infra, no migration, **no response-contract change**.
+
+**Success criteria:** latency drops from the *sum* of six sequential queries to roughly
+the *slowest* one (baseline: **5–10 s** observed live). Bytes scanned stay ~the same;
+this is deliberately a **latency** slice, not a cost slice.
+
+**Specs:** `docs/superpowers/specs/2026-07-16-game-detail-api-design.md`,
+`docs/superpowers/specs/2026-07-16-warehouse-services-architecture-design.md`
+
+## Why this shape (measured, not assumed)
+
+Dry-run measurements against live `analytics.games_features`:
+
+| Selection | Scanned |
+|---|---|
+| `SELECT *` (current) | 215.5 MB |
+| all except `description` | 83.5 MB |
+| `description` alone | 133.1 MB |
+| scalars only | 50.8 MB |
+
+Per request today: features 215.5 + player_counts 33.3 + similar 70.1 + provenance 26.7
++ embedding 9.4 + predictions 6.0 ≈ **361 MB**, run **sequentially** → 5–10 s live.
+
+We considered making `description` opt-in (would cut 361 → 229 MB) and **rejected it**:
+a ~37% saving is column-dimension only, it churns the API contract, and **clustering
+would make you want to reverse it** (with `clusterBy game_id`, `description` becomes
+nearly free). Column trimming here is therefore **hygiene only** — the real cost fix is
+clustering (follow-up), and the real win available *today* is concurrency.
+
+## Scope
+
+**In:** explicit column lists (replacing `SELECT *`) for hygiene and a small saving;
+splitting `get_features` so `/players` stops reading `games_features`; running
+`get_game`'s block queries concurrently; tests.
+
+**Out of scope:** `description` opt-in / any response-contract change (rejected above);
+`clusterBy game_id` (separate spec + plan — needs a Dataform change and full refresh);
+caching; games list/search; front-end work; PR #87 gating (independent).
+
+## Branching & delivery
+
+**Never commit to `main`.** Branch **`feature/warehouse-api-perf`** (off `main`, which
+includes merged PR #86). All task commits land there; one PR to `main`, squash-merged.
+Merging triggers `deploy-warehouse-api.yml` (paths include `src/warehouse/**`), which
+redeploys the service — no other workflow fires.
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/warehouse/readers/games.py` | Explicit columns; split `get_features`; concurrent `get_game` |
+| Modify | `tests/test_games_reader.py` | Column assertions + concurrency test |
+| Modify | `services/warehouse_api/routers/games.py` | `/players` → `get_player_counts` |
+| Modify | `tests/test_games_router.py` | Update mocks for new signatures |
+
+---
+
+### Task 1: Explicit columns (hygiene) + split `get_features`
+
+**Files:** `src/warehouse/readers/games.py`, `tests/test_games_reader.py`
+
+- [ ] **Step 1: Write failing tests.** Assert (a) no query contains `SELECT *`;
+  (b) `get_feature_row` and `get_player_counts` exist and query the right tables;
+  (c) `get_features` still returns the row with `player_counts` attached;
+  (d) `description` is **still present** in the selected columns (no contract change).
+- [ ] **Step 2: Run, watch fail** — `uv run --extra test python -m pytest tests/test_games_reader.py -v`.
+- [ ] **Step 3: Implement** — module-level `FEATURE_COLUMNS` / `PLAYER_COUNT_COLUMNS`;
+  replace `SELECT *` everywhere with explicit lists; split `get_features` into
+  `get_feature_row` + `get_player_counts` (composing in `get_features`).
+- [ ] **Step 4: Run, watch pass.**
+- [ ] **Step 5: Sanity-check bytes** — dry-run the new features query; expect ~the same
+  as before (~215 MB, since `description` stays). Record it; a big *increase* is a bug.
+- [ ] **Step 6: Commit** — `refactor(api): explicit column lists; split feature reads`
+
+---
+
+### Task 2: Concurrent block queries in `get_game`
+
+**Files:** `src/warehouse/readers/games.py`, `tests/test_games_reader.py`
+
+- [ ] **Step 1: Write failing tests.** (a) `get_game` still composes all six blocks and
+  still returns `None` when the features row is missing; (b) a **timing** test with a
+  fake client sleeping ~0.1 s per query — sequential would be ≥0.6 s, so assert the call
+  completes well under that (e.g. < 0.4 s), proving concurrency.
+- [ ] **Step 2: Run, watch fail** (the timing test fails while sequential).
+- [ ] **Step 3: Implement** — run the six leaf queries via `ThreadPoolExecutor` in
+  `get_game`, assembling after. `bigquery.Client` is thread-safe for query submission.
+- [ ] **Step 4: Run, watch pass.**
+- [ ] **Step 5: Commit** — `perf(api): run game block queries concurrently`
+
+---
+
+### Task 3: Router + PR
+
+**Files:** `services/warehouse_api/routers/games.py`, `tests/test_games_router.py`
+
+- [ ] **Step 1: Update tests** — `/players` calls `get_player_counts` (not
+  `get_features`), returning `[]` for an unknown game; other 200/404 behaviour unchanged.
+- [ ] **Step 2: Run, watch fail.**
+- [ ] **Step 3: Implement** the `/players` delegation.
+- [ ] **Step 4: Run, watch pass**, then the whole suite `-m "not integration"`.
+- [ ] **Step 5: Commit** — `perf(api): slim /players to player-count reads`
+- [ ] **Step 6: Push + open PR** to `main`:
+  `gh pr create --base main --title "perf(api): run game block queries concurrently"`.
+- [ ] **Step 7: After merge**, the deploy workflow redeploys. Re-measure live:
+  `curl -H "Authorization: Bearer $(gcloud auth print-identity-token)" <url>/games/13`
+  and compare wall-clock against the 5–10 s baseline. **Record the number** — it decides
+  how urgent clustering is.
+
+---
+
+## Risks / unknowns / rollback
+
+- **No early short-circuit:** concurrent `get_game` issues all six queries even for a
+  nonexistent game, so a 404 now costs a full scan instead of one query. 404s should be
+  rare; accepted deliberately for the latency win on the common path.
+- **Concurrency load:** six simultaneous BigQuery queries per request instead of one at
+  a time. Fine at current (zero) traffic; revisit under real load.
+- **Timing-test flakiness:** keep the bound generous (sleep 0.1 s, assert < 0.4 s) so CI
+  jitter doesn't fail it.
+- **Rollback:** pure code, no schema/infra. Revert the PR and redeploy.
+- **Honest ceiling:** a request still scans ~361 MB afterwards. This slice buys latency
+  only. **Clustering is the actual fix** and remains the next follow-up.

--- a/services/warehouse_api/routers/games.py
+++ b/services/warehouse_api/routers/games.py
@@ -32,7 +32,13 @@ def get_features(game_id: int):
 
 @router.get("/{game_id}/players")
 def get_players(game_id: int):
-    return _require(reader.get_features(game_id), game_id)["player_counts"]
+    """Per-player-count recommendations.
+
+    Reads the player-count table directly rather than the whole features row, so this
+    endpoint doesn't pay for a ``games_features`` scan it never uses. Returns an empty
+    list for an unknown game.
+    """
+    return reader.get_player_counts(game_id)
 
 
 @router.get("/{game_id}/predictions")

--- a/src/warehouse/readers/games.py
+++ b/src/warehouse/readers/games.py
@@ -7,6 +7,7 @@ interpolation). Tables are resolved through ``src.warehouse.bq.dataset`` so no
 project/dataset is hard-coded.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional
 
 from google.cloud import bigquery
@@ -168,16 +169,36 @@ def get_provenance(game_id: int, client: Optional[bigquery.Client] = None) -> Op
 
 
 def get_game(game_id: int, client: Optional[bigquery.Client] = None) -> Optional[dict[str, Any]]:
-    """Compose the full game document. ``None`` when the game has no features row."""
+    """Compose the full game document. ``None`` when the game has no features row.
+
+    The six block queries are issued **concurrently**, so wall-clock latency is the
+    slowest query rather than the sum of all six. ``bigquery.Client`` is thread-safe for
+    query submission.
+
+    Trade-off: there is no early short-circuit any more, so an unknown game costs all
+    six queries instead of one. Misses are rare; the common path is what matters.
+    """
     client = client or get_client()
-    features = get_features(game_id, client=client)
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        futures = {
+            "features": pool.submit(get_feature_row, game_id, client),
+            "player_counts": pool.submit(get_player_counts, game_id, client),
+            "predictions": pool.submit(get_predictions, game_id, client),
+            "embedding": pool.submit(get_embedding, game_id, client),
+            "similar": pool.submit(get_similar, game_id, 10, client),
+            "provenance": pool.submit(get_provenance, game_id, client),
+        }
+        results = {key: future.result() for key, future in futures.items()}
+
+    features = results["features"]
     if features is None:
         return None
+    features["player_counts"] = results["player_counts"]
     return {
         "game_id": game_id,
         "features": features,
-        "predictions": get_predictions(game_id, client=client),
-        "embedding": get_embedding(game_id, client=client),
-        "similar": get_similar(game_id, client=client),
-        "provenance": get_provenance(game_id, client=client),
+        "predictions": results["predictions"],
+        "embedding": results["embedding"],
+        "similar": results["similar"],
+        "provenance": results["provenance"],
     }

--- a/src/warehouse/readers/games.py
+++ b/src/warehouse/readers/games.py
@@ -13,6 +13,35 @@ from google.cloud import bigquery
 
 from src.warehouse.bq import dataset, get_client
 
+# Columns are listed explicitly rather than `SELECT *`. These serving tables are not
+# clustered on game_id, so a query scans every row of every column it names — and a
+# star-select would silently grow more expensive each time a column is added upstream.
+# The lists below reproduce the tables' current shape exactly (no contract change);
+# `description` stays included, since dropping it is a ~37% saving that clustering
+# would make you want to reverse.
+FEATURE_COLUMNS = [
+    "game_id", "name", "year_published",
+    "bayes_average", "average_rating", "average_weight", "users_rated",
+    "hurdle", "geek_rating", "complexity", "rating", "log_users_rated", "num_weights",
+    "min_players", "max_players", "min_playtime", "max_playtime", "min_age",
+    "image", "thumbnail", "description",
+    "categories", "mechanics", "publishers", "designers", "artists", "families",
+    "load_timestamp", "last_updated",
+]
+
+PLAYER_COUNT_COLUMNS = [
+    "game_id", "name", "player_count",
+    "best_votes", "recommended_votes", "not_recommended_votes", "total_votes",
+    "best_percentage", "recommended_percentage",
+]
+
+EMBEDDING_COLUMNS = [
+    "game_id", "umap_1", "umap_2", "pca_1", "pca_2",
+    "embedding_model", "embedding_version", "created_ts",
+]
+
+PROVENANCE_COLUMNS = ["record_id", "game_id", "fetch_timestamp", "fetch_status"]
+
 
 def _rows(client: bigquery.Client, sql: str, game_id: int, extra_params=None) -> list[dict]:
     params = [bigquery.ScalarQueryParameter("game_id", "INT64", game_id)]
@@ -22,32 +51,55 @@ def _rows(client: bigquery.Client, sql: str, game_id: int, extra_params=None) ->
     return [dict(row) for row in client.query(sql, job_config=job_config).result()]
 
 
-def get_features(game_id: int, client: Optional[bigquery.Client] = None) -> Optional[dict[str, Any]]:
-    """Game record + per-player-count recommendations. ``None`` if the game is unknown."""
+def get_feature_row(game_id: int, client: Optional[bigquery.Client] = None) -> Optional[dict[str, Any]]:
+    """The game's row from ``games_features`` (no player counts). ``None`` if unknown."""
     client = client or get_client()
     rows = _rows(
         client,
-        f"SELECT * FROM `{dataset('analytics')}.games_features` "
+        f"SELECT {', '.join(FEATURE_COLUMNS)} FROM `{dataset('analytics')}.games_features` "
         "WHERE game_id = @game_id LIMIT 1",
         game_id,
     )
-    if not rows:
-        return None
-    features = rows[0]
-    features["player_counts"] = _rows(
+    return rows[0] if rows else None
+
+
+def get_player_counts(game_id: int, client: Optional[bigquery.Client] = None) -> list[dict[str, Any]]:
+    """Per-player-count recommendation rows.
+
+    Split out from :func:`get_features` so ``/players`` can be served without scanning
+    ``games_features`` at all.
+    """
+    client = client or get_client()
+    return _rows(
         client,
-        f"SELECT * FROM `{dataset('analytics')}.player_count_recommendations` "
+        f"SELECT {', '.join(PLAYER_COUNT_COLUMNS)} "
+        f"FROM `{dataset('analytics')}.player_count_recommendations` "
         "WHERE game_id = @game_id ORDER BY player_count",
         game_id,
     )
+
+
+def get_features(game_id: int, client: Optional[bigquery.Client] = None) -> Optional[dict[str, Any]]:
+    """Game record + per-player-count recommendations. ``None`` if the game is unknown."""
+    client = client or get_client()
+    features = get_feature_row(game_id, client=client)
+    if features is None:
+        return None
+    features["player_counts"] = get_player_counts(game_id, client=client)
     return features
 
 
 def get_predictions(game_id: int, client: Optional[bigquery.Client] = None) -> Optional[dict[str, Any]]:
     """Latest prediction row plus ``first_prediction_ts``.
 
-    ``bgg_predictions`` holds one (latest) row per game; full time-series history would
-    read ``ml_predictions_landing`` and is deferred to a later slice.
+    ``bgg_predictions`` holds one (latest) row per game and is year-filtered, so older
+    games legitimately have no row. Full time-series history would read
+    ``ml_predictions_landing`` and is deferred to a later slice.
+
+    This is the one query that keeps a (qualified) ``p.*``: the column set is owned by
+    the ML pipeline and grows when new model outputs are added, so enumerating it here
+    would silently drop new predictions. At ~6 MB it is also the cheapest query, so
+    there is nothing to gain by pinning it.
     """
     client = client or get_client()
     rows = _rows(
@@ -68,7 +120,8 @@ def get_embedding(game_id: int, client: Optional[bigquery.Client] = None) -> Opt
     client = client or get_client()
     rows = _rows(
         client,
-        f"SELECT * FROM `{dataset('predictions')}.bgg_game_coordinates` "
+        f"SELECT {', '.join(EMBEDDING_COLUMNS)} "
+        f"FROM `{dataset('predictions')}.bgg_game_coordinates` "
         "WHERE game_id = @game_id",
         game_id,
     )
@@ -106,7 +159,8 @@ def get_provenance(game_id: int, client: Optional[bigquery.Client] = None) -> Op
     client = client or get_client()
     rows = _rows(
         client,
-        f"SELECT * FROM `{dataset('raw')}.fetched_responses` "
+        f"SELECT {', '.join(PROVENANCE_COLUMNS)} "
+        f"FROM `{dataset('raw')}.fetched_responses` "
         "WHERE game_id = @game_id LIMIT 1",
         game_id,
     )

--- a/tests/test_games_reader.py
+++ b/tests/test_games_reader.py
@@ -103,6 +103,41 @@ class TestSafety:
             assert "game_id" in names
 
 
+class TestConcurrency:
+    """get_game must issue its block queries in parallel, not one after another."""
+
+    def test_blocks_run_concurrently(self):
+        import time
+
+        class SlowClient(RoutingClient):
+            def query(self, sql, job_config=None):
+                time.sleep(0.1)
+                return super().query(sql, job_config)
+
+        client = SlowClient({
+            "games_features": [FEATURES_ROW],
+            "player_count_recommendations": PLAYER_COUNTS,
+            "bgg_predictions": [PREDICTION_ROW],
+            "bgg_game_coordinates": [COORD_ROW],
+            "game_similarity_search": SIMILAR_ROWS,
+            "fetched_responses": [PROVENANCE_ROW],
+        })
+        start = time.monotonic()
+        result = games.get_game(13, client=client)
+        elapsed = time.monotonic() - start
+
+        assert result is not None
+        assert len(client.calls) == 6
+        # Sequential would be >= 0.6s (6 x 0.1s). Bound kept generous for CI jitter.
+        assert elapsed < 0.4, f"queries appear sequential: {elapsed:.2f}s for 6 x 0.1s"
+
+    def test_still_composes_and_handles_missing_game(self):
+        assert set(games.get_game(13, client=_full_client())) == {
+            "game_id", "features", "predictions", "embedding", "similar", "provenance"
+        }
+        assert games.get_game(999999, client=RoutingClient({"games_features": []})) is None
+
+
 class TestExplicitColumns:
     """`SELECT *` scans every column of every row on these unclustered tables."""
 

--- a/tests/test_games_reader.py
+++ b/tests/test_games_reader.py
@@ -101,3 +101,30 @@ class TestSafety:
             assert "13" not in sql  # the literal id never appears in the SQL text
             names = {p.name for p in job_config.query_parameters}
             assert "game_id" in names
+
+
+class TestExplicitColumns:
+    """`SELECT *` scans every column of every row on these unclustered tables."""
+
+    def test_no_select_star_anywhere(self):
+        client = _full_client()
+        games.get_game(13, client=client)
+        for sql, _ in client.calls:
+            assert "SELECT *" not in sql, f"SELECT * found in: {sql[:80]}"
+
+    def test_features_query_still_selects_description(self):
+        """description stays in the default payload — no response-contract change."""
+        client = _full_client()
+        games.get_feature_row(13, client=client)
+        assert "description" in client.calls[-1][0]
+
+    def test_player_counts_readable_without_touching_games_features(self):
+        """/players should not pay for a games_features scan it never uses."""
+        client = _full_client()
+        assert games.get_player_counts(13, client=client) == PLAYER_COUNTS
+        assert all("games_features" not in sql for sql, _ in client.calls)
+
+    def test_get_features_still_composes_row_and_counts(self):
+        result = games.get_features(13, client=_full_client())
+        assert result["name"] == "Catan"
+        assert result["player_counts"] == PLAYER_COUNTS

--- a/tests/test_games_router.py
+++ b/tests/test_games_router.py
@@ -38,9 +38,15 @@ def test_predictions_sub_resource(monkeypatch):
 
 
 def test_players_sub_resource(monkeypatch):
+    """/players reads player counts directly — it must not scan games_features."""
+    def _boom(*a, **k):
+        raise AssertionError("/players must not read games_features")
+
+    monkeypatch.setattr(games_router.reader, "get_features", _boom)
+    monkeypatch.setattr(games_router.reader, "get_feature_row", _boom)
     monkeypatch.setattr(
-        games_router.reader, "get_features",
-        lambda game_id, client=None: {"name": "Catan", "player_counts": [{"player_count": "4"}]},
+        games_router.reader, "get_player_counts",
+        lambda game_id, client=None: [{"player_count": "4"}],
     )
     r = client.get("/games/13/players")
     assert r.status_code == 200


### PR DESCRIPTION
## What this is

A **latency** slice for `GET /games/{id}`. Code-only — no Dataform, no infra, no
migration, **no response-contract change**.

Baseline: the six block queries ran **sequentially**, giving **5–10 s** observed live on
the deployed service.

## Changes

1. **Concurrent block queries** (the actual win) — `get_game` issues its six queries via
   `ThreadPoolExecutor`, so latency is the *slowest* query rather than the *sum*.
   Proven by a timing test (6 × 0.1 s fake queries: **0.59 s sequential → < 0.4 s**).
2. **Explicit column lists** replacing `SELECT *` — hygiene: pinned columns stop an
   upstream column addition from silently inflating every query. Shapes preserved
   exactly.
3. **`/players` slimmed** — reads the player-count table directly instead of loading the
   whole features row, so it no longer scans `games_features` at all.

## Measurements (dry-run, free)

| Query | Before | After |
|---|---:|---:|
| features | 215.5 | 215.5 |
| similar | 70.1 | 70.2 |
| player_counts | 33.3 | 33.4 |
| provenance | 26.7 | 27.1 |
| embedding | 9.4 | 9.4 |
| predictions | 6.0 | 6.0 |
| **total** | **361.0 MB** | **361.6 MB** |

**Bytes are deliberately unchanged.** We considered making `description` opt-in
(361 → 229 MB) and **rejected it**: a ~37% column-dimension saving that churns the API
contract and that clustering would make you want to reverse. This PR buys **latency**;
clustering buys the bytes.

## Deliberate trade-offs

- **No early short-circuit:** an unknown game now costs six queries instead of one.
  Misses are rare; the common path wins.
- **`get_predictions` keeps a qualified `p.*`** — its column set is owned by the ML
  pipeline and grows with new model outputs, so pinning it would silently drop them.
  At 6 MB there's nothing to gain.

## Verification

- Full suite: **86 passed**. (The one failure, `test_refresh_games::test_config_loading`,
  is pre-existing on `main` — it asserts 4 refresh intervals while the config has 5.)
- Post-merge: re-measure `curl .../games/13` wall-clock against the 5–10 s baseline.

## Honest ceiling

A request still scans ~361 MB, because the serving tables are unclustered — every query
reads every row regardless of columns. **`clusterBy game_id` remains the real fix** and
is the next follow-up (needs its own spec + plan: Dataform change + full refresh).

Plan: `docs/superpowers/plans/2026-07-21-warehouse-api-reader-perf.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
