### PR TITLE
feat(dataform): game_profile + precomputed filtered neighbors

### DIFF
--- a/definitions/game_neighbors.sqlx
+++ b/definitions/game_neighbors.sqlx
@@ -1,0 +1,94 @@
+config {
+  type: "table",
+  schema: "analytics",
+  name: "game_neighbors",
+  description: "Precomputed FILTERED nearest-neighbour lists, one row per (profile, game). Mirrors the front-end's default similarity semantics (min ratings floor + source-relative complexity band) so the API can serve the common path from a single clustered lookup instead of scanning every embedding. Tuning parameters are carried on the row so the table is self-describing. Custom/tuned similarity is served live from game_similarity_search, not from here.",
+  bigquery: {
+    clusterBy: ["profile", "game_id"]
+  }
+}
+
+js {
+  // The one place similarity defaults are declared.
+  //
+  // To tune: add a NEW profile alongside the existing one, compare on real games, then
+  // flip which the API treats as default — rather than mutating `default` in place.
+  // A full rebuild is ~13s / ~72MB per profile, so extra profiles are effectively free.
+  //
+  // Note: `complexity` here is bgg_complexity_predictions.predicted_complexity, as
+  // surfaced by game_similarity_search.
+  const PROFILES = [
+    {
+      name: "default",
+      min_users_rated: 100,   // matches DEFAULT_MIN_RATINGS in the viewer
+      complexity_band: 0.75,  // source-relative: |candidate - source| <= band
+      distance: "COSINE",
+      dims: 64,
+      top_k: 10
+    }
+  ];
+
+  // 64-d lives in `embedding`; reduced dims in embedding_8/16/32.
+  function embeddingColumn(dims) {
+    return dims === 64 ? "embedding" : `embedding_${dims}`;
+  }
+}
+
+WITH
+${PROFILES.map(p => `
+candidates_${p.name} AS (
+  SELECT
+    game_id,
+    name,
+    year_published,
+    complexity,
+    ${embeddingColumn(p.dims)} AS embedding
+  FROM ${ref("game_similarity_search")}
+  WHERE users_rated >= ${p.min_users_rated}
+    AND complexity IS NOT NULL
+),
+
+-- Source-relative band: the candidate set depends on the query game's own complexity,
+-- which is exactly why an unfiltered global top-N cannot reproduce these results.
+pairs_${p.name} AS (
+  SELECT
+    s.game_id AS src_game_id,
+    t.game_id AS nbr_game_id,
+    t.name AS nbr_name,
+    t.year_published AS nbr_year_published,
+    ML.DISTANCE(s.embedding, t.embedding, '${p.distance}') AS distance
+  FROM candidates_${p.name} s
+  JOIN candidates_${p.name} t
+    ON t.game_id != s.game_id
+   AND t.complexity BETWEEN s.complexity - ${p.complexity_band}
+                        AND s.complexity + ${p.complexity_band}
+),
+
+ranked_${p.name} AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY src_game_id ORDER BY distance) AS rn
+  FROM pairs_${p.name}
+)`).join(",\n")}
+
+${PROFILES.map(p => `
+SELECT
+  '${p.name}' AS profile,
+  src_game_id AS game_id,
+  ARRAY_AGG(
+    STRUCT(
+      nbr_game_id AS game_id,
+      nbr_name AS name,
+      nbr_year_published AS year_published,
+      distance
+    )
+    ORDER BY distance
+  ) AS similar,
+  ${p.min_users_rated} AS min_users_rated,
+  ${p.complexity_band} AS complexity_band,
+  '${p.distance}' AS distance_type,
+  ${p.dims} AS embedding_dims,
+  CURRENT_TIMESTAMP() AS computed_ts
+FROM ranked_${p.name}
+WHERE rn <= ${p.top_k}
+GROUP BY src_game_id`).join("\nUNION ALL\n")}

--- a/definitions/game_profile.sqlx
+++ b/definitions/game_profile.sqlx
@@ -1,0 +1,114 @@
+config {
+  type: "table",
+  schema: "analytics",
+  name: "game_profile",
+  description: "One row per game holding everything the read API serves for a single game: features, per-player-count recommendations (nested), latest predictions, embedding coordinates and fetch provenance. Collapses a six-query fan-out (~361MB) into one clustered lookup (~10MB) — BigQuery bills a 10MB minimum PER TABLE referenced, so fewer tables matters more than fewer columns. Similar games are deliberately NOT here: neighbour semantics are source-relative and user-tunable (see game_neighbors).",
+  bigquery: {
+    clusterBy: ["game_id"]
+  }
+}
+
+WITH player_counts_agg AS (
+  SELECT
+    game_id,
+    ARRAY_AGG(
+      STRUCT(
+        player_count,
+        best_votes,
+        recommended_votes,
+        not_recommended_votes,
+        total_votes,
+        best_percentage,
+        recommended_percentage
+      )
+      ORDER BY player_count
+    ) AS player_counts
+  FROM ${ref("player_count_recommendations")}
+  GROUP BY game_id
+),
+
+-- raw.fetched_responses can hold several fetch records per game; keep the newest.
+provenance_latest AS (
+  SELECT game_id, fetch_timestamp, fetch_status
+  FROM (
+    SELECT
+      game_id,
+      fetch_timestamp,
+      fetch_status,
+      ROW_NUMBER() OVER (PARTITION BY game_id ORDER BY fetch_timestamp DESC) AS rn
+    FROM ${ref("fetched_responses")}
+  )
+  WHERE rn = 1
+)
+
+SELECT
+  f.game_id,
+
+  -- Feature scalars (kept flat so the table is usable for ad-hoc analysis too)
+  f.name,
+  f.year_published,
+  f.bayes_average,
+  f.average_rating,
+  f.average_weight,
+  f.users_rated,
+  f.hurdle,
+  f.geek_rating,
+  f.complexity,
+  f.rating,
+  f.log_users_rated,
+  f.num_weights,
+  f.min_players,
+  f.max_players,
+  f.min_playtime,
+  f.max_playtime,
+  f.min_age,
+  f.image,
+  f.thumbnail,
+  f.description,
+
+  -- Existing repeated name columns, carried through unchanged
+  f.categories,
+  f.mechanics,
+  f.publishers,
+  f.designers,
+  f.artists,
+  f.families,
+
+  f.load_timestamp,
+  f.last_updated,
+
+  -- Multi-row block collapsed into a nested array
+  COALESCE(pc.player_counts, []) AS player_counts,
+
+  -- Single-row blocks collapsed into structs. LEFT JOINed, so a game with no
+  -- predictions/embedding/provenance still yields a row (the struct is NULL).
+  IF(p.game_id IS NULL, NULL, STRUCT(
+    p.predicted_hurdle_prob,
+    p.predicted_complexity,
+    p.predicted_rating,
+    p.predicted_users_rated,
+    p.predicted_geek_rating,
+    p.score_ts,
+    fp.first_prediction_ts
+  )) AS predictions,
+
+  IF(co.game_id IS NULL, NULL, STRUCT(
+    co.umap_1,
+    co.umap_2,
+    co.pca_1,
+    co.pca_2,
+    co.embedding_model,
+    co.embedding_version
+  )) AS embedding,
+
+  IF(pr.game_id IS NULL, NULL, STRUCT(
+    pr.fetch_timestamp,
+    pr.fetch_status
+  )) AS provenance
+
+FROM ${ref("games_features")} f
+LEFT JOIN player_counts_agg pc ON pc.game_id = f.game_id
+LEFT JOIN ${ref("bgg_predictions")} p ON p.game_id = f.game_id
+LEFT JOIN ${ref("game_first_prediction")} fp ON fp.game_id = f.game_id
+LEFT JOIN ${ref("bgg_game_coordinates")} co ON co.game_id = f.game_id
+LEFT JOIN provenance_latest pr ON pr.game_id = f.game_id

--- a/definitions/game_profile.sqlx
+++ b/definitions/game_profile.sqlx
@@ -27,6 +27,15 @@ WITH player_counts_agg AS (
   GROUP BY game_id
 ),
 
+-- Whole-row struct, so the predictions block stays faithful to bgg_predictions
+-- (including all model-metadata columns) and picks up new ML outputs automatically
+-- rather than silently dropping them.
+predictions_joined AS (
+  SELECT p.*, fp.first_prediction_ts
+  FROM ${ref("bgg_predictions")} p
+  LEFT JOIN ${ref("game_first_prediction")} fp ON fp.game_id = p.game_id
+),
+
 -- raw.fetched_responses can hold several fetch records per game; keep the newest.
 provenance_latest AS (
   SELECT game_id, fetch_timestamp, fetch_status
@@ -82,15 +91,7 @@ SELECT
 
   -- Single-row blocks collapsed into structs. LEFT JOINed, so a game with no
   -- predictions/embedding/provenance still yields a row (the struct is NULL).
-  IF(p.game_id IS NULL, NULL, STRUCT(
-    p.predicted_hurdle_prob,
-    p.predicted_complexity,
-    p.predicted_rating,
-    p.predicted_users_rated,
-    p.predicted_geek_rating,
-    p.score_ts,
-    fp.first_prediction_ts
-  )) AS predictions,
+  IF(pj.game_id IS NULL, NULL, pj) AS predictions,
 
   IF(co.game_id IS NULL, NULL, STRUCT(
     co.umap_1,
@@ -108,7 +109,6 @@ SELECT
 
 FROM ${ref("games_features")} f
 LEFT JOIN player_counts_agg pc ON pc.game_id = f.game_id
-LEFT JOIN ${ref("bgg_predictions")} p ON p.game_id = f.game_id
-LEFT JOIN ${ref("game_first_prediction")} fp ON fp.game_id = f.game_id
+LEFT JOIN predictions_joined pj ON pj.game_id = f.game_id
 LEFT JOIN ${ref("bgg_game_coordinates")} co ON co.game_id = f.game_id
 LEFT JOIN provenance_latest pr ON pr.game_id = f.game_id

--- a/definitions/game_similarity_search.sqlx
+++ b/definitions/game_similarity_search.sqlx
@@ -3,7 +3,16 @@ config {
   schema: "analytics",
   name: "game_similarity_search",
   uniqueKey: ["game_id"],
-  description: "Game embeddings enriched with features for similarity search. Combines embeddings from predictions with game metadata for filtering by year, rating, complexity, etc."
+  description: "Game embeddings enriched with features for similarity search. Combines embeddings from predictions with game metadata for filtering by year, rating, complexity, etc. Clustered on users_rated + complexity: the similarity query filters on THOSE columns (never on game_id) and then ranks every survivor, so clustering by game_id would prune nothing.",
+  bigquery: {
+    // Deliberately NOT game_id. Live similarity filters `users_rated >= N` (applied on
+    // essentially every query; alone cuts 127,645 -> 17,258 rows, ~86%) and then a
+    // source-relative complexity band, before ranking. users_rated is therefore the
+    // right prefix key, with complexity second for the band tweak.
+    // NOTE: clustering cannot be added to an existing table in place -- this needs a
+    // FULL REFRESH to take effect (see 2026-03-31-dataform-incremental-schema-drift).
+    clusterBy: ["users_rated", "complexity"]
+  }
 }
 
 SELECT

--- a/docs/superpowers/plans/2026-07-21-game-profile-and-neighbors.md
+++ b/docs/superpowers/plans/2026-07-21-game-profile-and-neighbors.md
@@ -1,0 +1,158 @@
+# Game Profile & Precomputed Neighbors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut `GET /games/{id}` from ~361 MB to ~20 MB per request, and fix the
+unfiltered `/similar` defect, by adding two Dataform serving models and repointing the
+API at them.
+
+**Spec:** `docs/superpowers/specs/2026-07-21-game-profile-and-neighbors-design.md`
+
+**Tech Stack:** Dataform (BigQuery), Python 3.12, FastAPI, GitHub Actions.
+
+## Scope
+
+**In:** `definitions/game_profile.sqlx`, `definitions/game_neighbors.sqlx`, a clustering
+change to `definitions/game_similarity_search.sqlx`, the games reader + router, tests.
+
+**Out of scope:** caching (the residual ~1 s is BigQuery per-query overhead); extra
+neighbour profiles per distance metric (deferred); front-end work; any response-contract
+change.
+
+## Branching & delivery
+
+**Never commit to `main`.** This lands as **two PRs in order**, because the API cannot
+read tables that don't exist yet:
+
+1. **PR A — `feature/game-profile-neighbors`** (Dataform only). Merging triggers
+   `dataform.yml` (paths include `definitions/**`), which builds the new tables.
+2. **PR B — `feature/api-profile-reads`** (API only). Merge **after** PR A's Dataform
+   run has succeeded and the tables are populated. Merging triggers
+   `deploy-warehouse-api.yml`.
+
+Both squash-merge to `main`. No local `terraform`/`gcloud`/deploys — everything via
+Actions.
+
+---
+
+## PR A — Dataform models
+
+### Task 1: `game_neighbors` (precomputed filtered similarity)
+
+**Files:** Create `definitions/game_neighbors.sqlx`
+
+- [ ] **Step 1: Write the model.** `type: "table"`, `schema: "analytics"`,
+  `bigquery: { clusterBy: ["profile", "game_id"] }`. Declare profiles once as a JS array:
+  ```js
+  const PROFILES = [
+    { name: "default", min_users_rated: 100, complexity_band: 0.75,
+      distance: "COSINE", dims: 64, top_k: 10 },
+  ];
+  ```
+  Generate one `UNION ALL` branch per profile: filter candidates
+  (`users_rated >= min_users_rated`), self-join on the source-relative complexity band,
+  rank by `ML.DISTANCE(..., distance)`, keep `top_k`, `ARRAY_AGG(STRUCT(...))`. Carry
+  the profile params as columns.
+- [ ] **Step 2: Validate the generated SQL by dry-run** before committing — paste the
+  resolved query (with `${ref()}` expanded) into a dry run; expect **~72 MB**.
+  A large deviation means the filter/join is wrong.
+- [ ] **Step 3: Verify semantics** — run it for game 13 and confirm the filtered list
+  (Lords of Vegas, Chinatown, CATAN: 3D Edition …) and that **Catan Connect is absent**.
+- [ ] **Step 4: Commit** — `feat(dataform): precompute filtered game neighbors`
+
+### Task 2: `game_profile` (one row per game)
+
+**Files:** Create `definitions/game_profile.sqlx`
+
+- [ ] **Step 1: Write the model.** `type: "table"`, `schema: "analytics"`,
+  `bigquery: { clusterBy: ["game_id"] }`. Join `games_features` +
+  `player_count_recommendations` (as `ARRAY_AGG(STRUCT(...))`) + `bgg_predictions` /
+  `game_first_prediction` (STRUCT) + `bgg_game_coordinates` (STRUCT) +
+  `fetched_responses` (STRUCT), per the spec's shape. `LEFT JOIN` every optional block so
+  a game with no predictions still yields a row.
+- [ ] **Step 2: Dry-run the resolved SQL** — expect ~290 MB for a full build.
+- [ ] **Step 3: Verify the shape matches the current API response** for game 13
+  field-for-field (names, arrays, nested structs).
+- [ ] **Step 4: Commit** — `feat(dataform): add game_profile serving model`
+
+### Task 3: Cluster `game_similarity_search`
+
+**Files:** Modify `definitions/game_similarity_search.sqlx`
+
+- [ ] **Step 1: Add** `bigquery: { clusterBy: ["users_rated", "complexity"] }` to the
+  config. **Not `game_id`** — the live similarity query filters on `users_rated` and
+  `complexity`, never on `game_id` (see spec).
+- [ ] **Step 2: Note the refresh requirement in the PR body** — this is an *incremental*
+  model and clustering cannot be added in place, so it needs a **full refresh** to take
+  effect (see the incremental-schema-drift spec).
+- [ ] **Step 3: Commit** — `perf(dataform): cluster similarity search on filter columns`
+
+### Task 4: Open PR A
+
+- [ ] **Step 1: Push + open PR** describing the full-refresh requirement for
+  `game_similarity_search`.
+- [ ] **Step 2: After merge**, confirm the `dataform.yml` run succeeded and that
+  `game_profile` / `game_neighbors` are populated (row counts ≈ 127,645 and 17,258).
+- [ ] **Step 3: Trigger the full refresh** for `game_similarity_search` so clustering
+  takes effect, then confirm pruning by comparing a filtered query's dry-run estimate
+  against bytes **billed** (dry run alone cannot show pruning).
+
+---
+
+## PR B — API repoint
+
+### Task 5: Reader — `similar` from precomputed, live fallback
+
+**Files:** `src/warehouse/readers/games.py`, `tests/test_games_reader.py`
+
+- [ ] **Step 1: Write failing tests.** (a) `get_similar(game_id)` with no params reads
+  `game_neighbors` and filters `profile='default'`; (b) passing any tuning parameter
+  (band/metric/min_ratings/dims/n) routes to the **live** query against
+  `game_similarity_search`; (c) the live query applies the `users_rated` floor **and**
+  the source-relative complexity band — the defect regression test.
+- [ ] **Step 2: Run, watch fail.**
+- [ ] **Step 3: Implement** — `get_similar(game_id, *, profile="default", band=None,
+  metric=None, min_ratings=None, dims=None, n=None)`; precomputed path when all tuning
+  params are `None`, else live filtered query.
+- [ ] **Step 4: Run, watch pass.**
+- [ ] **Step 5: Commit** — `fix(api): serve filtered neighbors; live query when tuned`
+
+### Task 6: Reader — `get_game` from `game_profile`
+
+**Files:** `src/warehouse/readers/games.py`, `tests/test_games_reader.py`
+
+- [ ] **Step 1: Write failing tests** — `get_game` issues **one** query against
+  `game_profile` and returns the same document shape (same top-level keys, features with
+  `player_counts`).
+- [ ] **Step 2: Run, watch fail.**
+- [ ] **Step 3: Implement** — single read; unpack nested structs/arrays into the existing
+  response shape. Keep the per-block readers for the sub-resource endpoints.
+- [ ] **Step 4: Run, watch pass** (the concurrency timing test becomes moot for
+  `get_game` — remove or retarget it rather than leaving it asserting stale behaviour).
+- [ ] **Step 5: Commit** — `perf(api): serve get_game from game_profile in one query`
+
+### Task 7: Router + PR B
+
+**Files:** `services/warehouse_api/routers/games.py`, `tests/test_games_router.py`
+
+- [ ] **Step 1: Tests** — `/games/{id}/similar` accepts `band`, `metric`, `min_ratings`,
+  `dims`, `n`, `profile`, and passes them through; bare call hits the precomputed path.
+- [ ] **Step 2: Implement**, run full suite `-m "not integration"`.
+- [ ] **Step 3: Commit + open PR B.**
+- [ ] **Step 4: After merge**, re-measure live: bytes/request vs the 361 MB baseline and
+  wall-clock vs ~1.2 s. **Record both.**
+
+---
+
+## Risks / rollback
+
+- **`game_similarity_search` full refresh** is the only destructive-ish step: it rebuilds
+  a serving table the live API reads. The API's `/similar` keeps working throughout
+  (same schema, only clustering changes), but the rebuild window is real.
+- **Ordering:** PR B before PR A = the API queries non-existent tables → 5xx. Enforced by
+  the two-PR sequence.
+- **Shape drift:** if `game_profile` doesn't reproduce the current document exactly, the
+  response contract silently changes. Task 2 Step 3 is the guard.
+- **Rollback:** PR B is pure code — revert and redeploy. PR A's new tables are additive
+  (dropping them affects nothing until PR B lands); the clustering change reverts by
+  removing `clusterBy` and refreshing again.

--- a/docs/superpowers/specs/2026-07-21-game-profile-and-neighbors-design.md
+++ b/docs/superpowers/specs/2026-07-21-game-profile-and-neighbors-design.md
@@ -1,0 +1,191 @@
+# Game Profile & Precomputed Neighbors
+
+## Problem
+
+Two things are wrong with how the warehouse read API serves a game.
+
+**1. Cost.** `GET /games/{id}` fans out to six queries across ~7 tables and scans
+**~361 MB per request**. None of the serving tables are clustered, so every point-lookup
+reads every row. At 361 MB you exhaust the 1 TiB/month free tier in **~2,900 requests**
+(under 100/day); 50k requests/month would cost ~**$81**.
+
+**2. A correctness defect.** `GET /games/{id}/similar` is **unfiltered** — raw
+`ML.DISTANCE` with no `users_rated` floor and no complexity band. It does not match the
+semantics the front-end actually uses, and surfaces near-unrated obscure games:
+
+| Unfiltered (API today) | Filtered (front-end's real config) |
+|---|---|
+| Catan Connect (0.070) | Lords of Vegas (0.191) |
+| Loot the World (0.122) | Chinatown (0.198) |
+| Springsign (0.167) | CATAN: 3D Edition (0.199) |
+
+The live front-end applies `users_rated >= 100` **and** complexity within ±0.75 of the
+source game, **before** ranking. A global unfiltered neighbour list can't reproduce that.
+
+## Measurements (all verified, not estimated)
+
+- Today: 361 MB/request; ~1.2 s latency (after the concurrency slice).
+- **BigQuery bills a 10 MB minimum per table referenced** — so a 7-table fan-out can
+  never go below ~70 MB, however well clustered. Fewer tables is worth more than
+  fewer columns.
+- Corpus: **127,645** games with embeddings (64-d, plus 8/16/32-d reductions);
+  **17,258** have `users_rated >= 100`, all with complexity.
+- **Filtered precompute of neighbours for all 17,258 games: 13.1 s, 72.4 MB, $0.0003.**
+- Unfiltered all-pairs (127,645² = 16.3 B) **fails** on resource limits after ~6 min.
+- Clustering is real: a clustered table pruned **85.8%** (606 MB → 86 MB billed);
+  unclustered tables pruned 0%.
+- Latency floor is BigQuery per-query overhead (~0.9 s), *not* bytes — a clustered
+  86 MB query took longer than an unclustered 216 MB one. **This work is about cost,
+  not latency.**
+
+## Solution
+
+Three data changes plus an API change.
+
+### 1. `analytics.game_profile` — one row per game
+
+Collapses the four cheap-to-join blocks into a single clustered row, so `get_game`
+becomes **one** query (~10 MB) instead of six (~361 MB). Multi-row blocks become
+nested arrays; single-row blocks become structs.
+
+```
+analytics.game_profile                      -- clustered by game_id
+  game_id INT64
+  name, year_published, bayes_average, average_rating, average_weight, users_rated,
+  min_players, max_players, min_playtime, max_playtime, min_age,
+  image, thumbnail, description
+  categories, mechanics, publishers, designers, artists, families  ARRAY<STRING>
+  player_counts ARRAY<STRUCT<player_count STRING, best_votes INT64,
+                             recommended_votes INT64, not_recommended_votes INT64,
+                             total_votes INT64, best_percentage FLOAT64,
+                             recommended_percentage FLOAT64>>
+  predictions   STRUCT<predicted_hurdle_prob FLOAT64, predicted_complexity FLOAT64,
+                       predicted_rating FLOAT64, predicted_users_rated FLOAT64,
+                       predicted_geek_rating FLOAT64, score_ts TIMESTAMP,
+                       first_prediction_ts TIMESTAMP>
+  embedding     STRUCT<umap_1 FLOAT64, umap_2 FLOAT64, pca_1 FLOAT64, pca_2 FLOAT64,
+                       embedding_model STRING, embedding_version INT64>
+  provenance    STRUCT<fetch_timestamp TIMESTAMP, fetch_status STRING>
+```
+
+This is deliberately **the same shape as the existing API response**, so structs/arrays
+serialize straight through and the response contract does not change.
+
+`similar` is **not** in the profile: neighbour semantics are source-relative and
+user-tunable (below).
+
+### 2. `analytics.game_neighbors` — precomputed *filtered* neighbours
+
+```
+analytics.game_neighbors                    -- clustered by (profile, game_id)
+  profile STRING                            -- 'default'
+  game_id INT64
+  similar ARRAY<STRUCT<game_id INT64, name STRING,
+                       year_published FLOAT64, distance FLOAT64>>
+  min_users_rated INT64, complexity_band FLOAT64,
+  distance_type STRING, embedding_dims INT64, computed_ts TIMESTAMP
+```
+
+Parameters are carried **on the row** so the table is self-describing and the API never
+hardcodes an assumption about what "default" means.
+
+Profiles are declared once as a JS array in the `.sqlx` (Dataform templates JS):
+
+```js
+const PROFILES = [
+  { name: "default", min_users_rated: 100, complexity_band: 0.75,
+    distance: "COSINE", dims: 64, top_k: 10 },
+];
+```
+
+**Tuning workflow:** add a second profile alongside the current one (~13 s each),
+compare on real games, and flip the default only once satisfied — rather than mutating
+the live default in place. That is what the `profile` column buys.
+
+### 3. Clustering — on the columns actually filtered
+
+| Table | Cluster by | Why |
+|---|---|---|
+| `game_profile` | `game_id` | point lookup by id |
+| `game_neighbors` | `profile, game_id` | point lookup by id within a profile |
+| `game_similarity_search` | **`users_rated, complexity`** | the live query filters on *these*, never on `game_id` |
+
+The third is the non-obvious one. Clustering the similarity table by `game_id` would
+buy **nothing** — the live query filters by `users_rated` and `complexity` and then
+ranks every survivor. `users_rated >= 100` is applied on essentially every query and
+alone cuts 127,645 → 17,258 (86%), so it is the right prefix key; `complexity` second
+serves the band tweak. Expected: live similarity **70 MB → ~10–15 MB**.
+
+### 4. API behaviour
+
+- `GET /games/{id}` → single read of `game_profile`.
+- `GET /games/{id}/similar` (no params) → `game_neighbors`, `profile='default'` —
+  **fixes the unfiltered defect**.
+- `GET /games/{id}/similar?band=…&metric=…&min_ratings=…&dims=…&n=…` → any parameter
+  present falls through to the **live** filtered query against
+  `game_similarity_search`.
+
+Same semantics either way: the precomputed table is a materialized cache of one
+parameter set, not a different feature. This matches the intended front-end UX —
+precomputed default on page load, live endpoint when the user tweaks.
+
+**What is and isn't precomputable:** `distance_type` is discrete (3 values) and could
+become extra profiles; the **complexity band is a continuous slider** and can never be
+fully precomputed — it must stay live, which is exactly why clustering on `complexity`
+matters. Dimension tweaks are already cheap via `embedding_8/16/32` (8× less data).
+
+## Refresh strategy
+
+Both new models are built as **full-rebuild tables**, not incremental — they join
+several upstream tables whose change-detection would otherwise need bespoke logic, and
+the rebuild is trivially cheap:
+
+- `game_profile`: ~290 MB per build
+- `game_neighbors`: ~72 MB per build (13 s)
+
+At a few Dataform runs/day that's well inside the free tier — and it replaces **361 MB
+on every request**. One rebuild costs about as much as one request does today.
+
+## Expected outcome
+
+| | Per request | Free-tier ceiling | 50k req/mo |
+|---|---:|---:|---:|
+| Today | 361 MB | ~2,900 | $81 |
+| **After** | **~20 MB** | **~50,000** | **~$0** |
+
+Latency is expected to stay ~1 s (the BigQuery per-query floor), though `get_game`
+drops from six concurrent queries to one.
+
+## Validation
+
+- Unit tests (mocked BigQuery) for the new readers.
+- `game_profile` row for game 13 matches today's composed document field-for-field.
+- `game_neighbors` for game 13 reproduces the filtered list (Lords of Vegas, Chinatown,
+  CATAN: 3D Edition …) — and specifically **no longer** returns Catan Connect.
+- Post-deploy: re-measure bytes/request against the 361 MB baseline.
+- Confirm the clustered similarity table actually prunes (compare dry-run estimate vs
+  bytes *billed* — dry run alone cannot show pruning).
+
+## What this doesn't change
+
+- **No response-contract change** — the profile is shaped to the existing JSON.
+- No live inference; no write endpoints.
+- The `raw`/`core` pipeline, its schedules, and Dataform's existing models are untouched
+  apart from the clustering change to `game_similarity_search`.
+
+## Risks
+
+- **`game_similarity_search` clustering needs a full refresh** — clustering can't be
+  added to an existing table in place (see the incremental-schema-drift spec). It is an
+  incremental model, so this is a real rebuild of a serving table the live API reads.
+- **Staleness** is bounded by the Dataform cadence, which already gates everything else.
+- **Dropping to one query** removes the natural per-block isolation: a schema change in
+  any source now breaks one model rather than one endpoint. Mitigated by the profile
+  being a plain rebuild.
+
+## Deferred
+
+- Extra `game_neighbors` profiles per distance metric (cheap; add when the front-end
+  wants them).
+- Caching in front of the API — the remaining ~1 s is BigQuery per-query overhead, and
+  only a cache removes that.


### PR DESCRIPTION
## What this is

**PR A of 2** — the Dataform side. Adds two serving models and one clustering change so
the read API can serve a game from ~20 MB instead of ~361 MB, and so `/similar` returns
the *filtered* neighbours the front-end actually uses.

**No API code changes here** — the API keeps working exactly as today. PR B repoints it
once these tables exist.

Spec: `docs/superpowers/specs/2026-07-21-game-profile-and-neighbors-design.md`
Plan: `docs/superpowers/plans/2026-07-21-game-profile-and-neighbors.md`

## Why

- `GET /games/{id}` fans out over ~7 tables at **361 MB/request**. BigQuery bills a
  **10 MB minimum per table referenced**, so *fewer tables* matters more than fewer
  columns — hence one profile row rather than a six-query join.
- `GET /games/{id}/similar` is currently **unfiltered** and doesn't match the front-end,
  surfacing near-unrated games. A **defect**, fixed by `game_neighbors`.

## Changes

**1. `analytics.game_neighbors`** (new, clustered `profile, game_id`) — precomputed
**filtered** neighbours matching the front-end default (`users_rated >= 100`,
source-relative complexity band ±0.75, cosine, 64-d, top 10). Profiles are declared once
in a JS array; parameters are carried on the row so the table is self-describing. To
tune, add a profile alongside and flip the default once happy.

**2. `analytics.game_profile`** (new, clustered `game_id`) — one row per game: flat
feature scalars, nested `player_counts` array, and `predictions` / `embedding` /
`provenance` structs. `predictions` is a whole-row struct so all model metadata carries
through and new ML outputs appear automatically.

**3. `game_similarity_search`** — `clusterBy ["users_rated", "complexity"]`.
Deliberately **not** `game_id`: the live similarity query filters on those two columns
and ranks every survivor, so `game_id` clustering would prune nothing.

## Verified (executed, not estimated)

| | Result |
|---|---|
| `game_neighbors` build | **15.1 s, 72.4 MB, 17,258 rows** |
| Neighbour semantics | Catan → Lords of Vegas / Chinatown / CATAN: 3D — **Catan Connect correctly absent** |
| `game_profile` build | 271 MB dry-run |
| `game_profile` fidelity | matches the live API document field-for-field for games 13 and 367518 (incl. `umap_1 = 11.71465015411377`) |
| NULL handling | `predictions IS NULL` for year-filtered Catan; 30 fields incl. 15 model-metadata for Imperium |

Expected after PR B: **361 MB → ~20 MB per request** (~2,900 → ~50,000 requests inside
the free tier).

## ⚠️ Requires a full refresh

`game_similarity_search` is an **incremental** model and **clustering cannot be added to
an existing table in place** — it needs a **full refresh** to take effect (see
`2026-03-31-dataform-incremental-schema-drift`). Until then the clustering is declared
but inert (queries keep working, just uncosted-down).

The two new models are `type: "table"`, so they build fresh on the first Dataform run.

## Merge notes

Merging triggers `dataform.yml` (paths include `definitions/**`). After it succeeds,
confirm row counts (~127,645 for `game_profile`, ~17,258 for `game_neighbors`), then
trigger the full refresh for `game_similarity_search`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
