### PR TITLE
fix(dataform): declare raw.fetched_responses source (unblocks Dataform)

### DIFF
--- a/definitions/sources.js
+++ b/definitions/sources.js
@@ -22,6 +22,12 @@ coreTables.forEach(table => {
   });
 });
 
+// Local raw source: BGG fetch metadata (used for per-game provenance in game_profile)
+declare({
+  schema: "raw",
+  name: "fetched_responses"
+});
+
 // Cross-project source: ML predictions from bgg-predictive-models
 declare({
   database: "bgg-predictive-models",


### PR DESCRIPTION
## Urgent — Dataform is currently broken on `main`

After #90 merged, the Dataform run **failed to compile**:

```
Could not resolve "fetched_responses"
Missing dependency detected: Action "analytics.game_profile" depends on
"fetched_responses" which does not exist
```

`game_profile` refs `raw.fetched_responses` for the provenance block, but that table was
never declared as a Dataform source. **All Dataform runs fail until this merges** —
including the daily pipeline, not just the new models.

## Fix

Declare the local `raw.fetched_responses` source in `definitions/sources.js`. One
declaration; no model changes.

## Verified

Compiled the branch via the Dataform API (metadata only — runs nothing):

- **compilation errors: 0**
- 44 actions in the graph, with `game_profile`, `game_neighbors` and
  `game_similarity_search` all **PRESENT**

## How this slipped through

I validated the new models by dry-running their SQL with hard-coded table names, which
proved the SQL was correct but never exercised Dataform's `ref()` resolution. Compiling
against the Dataform API (as done here) is the check that catches it, and is what I
should have run before #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)