### PR TITLE
fix(dataform): game_profile duplicate first_prediction_ts (unblocks Dataform)

### DIFF
--- a/definitions/game_profile.sqlx
+++ b/definitions/game_profile.sqlx
@@ -27,15 +27,6 @@ WITH player_counts_agg AS (
   GROUP BY game_id
 ),
 
--- Whole-row struct, so the predictions block stays faithful to bgg_predictions
--- (including all model-metadata columns) and picks up new ML outputs automatically
--- rather than silently dropping them.
-predictions_joined AS (
-  SELECT p.*, fp.first_prediction_ts
-  FROM ${ref("bgg_predictions")} p
-  LEFT JOIN ${ref("game_first_prediction")} fp ON fp.game_id = p.game_id
-),
-
 -- raw.fetched_responses can hold several fetch records per game; keep the newest.
 provenance_latest AS (
   SELECT game_id, fetch_timestamp, fetch_status
@@ -91,7 +82,12 @@ SELECT
 
   -- Single-row blocks collapsed into structs. LEFT JOINed, so a game with no
   -- predictions/embedding/provenance still yields a row (the struct is NULL).
-  IF(pj.game_id IS NULL, NULL, pj) AS predictions,
+  -- Whole-row struct, so the predictions block stays faithful to bgg_predictions
+  -- (all model-metadata columns) and picks up new ML outputs automatically.
+  -- bgg_predictions ALREADY carries first_prediction_ts / is_new_1d / is_new_7d via its
+  -- own join to game_first_prediction — re-joining here would duplicate the field name,
+  -- which a SELECT tolerates but CREATE TABLE (a struct column) rejects.
+  IF(p.game_id IS NULL, NULL, p) AS predictions,
 
   IF(co.game_id IS NULL, NULL, STRUCT(
     co.umap_1,
@@ -109,6 +105,6 @@ SELECT
 
 FROM ${ref("games_features")} f
 LEFT JOIN player_counts_agg pc ON pc.game_id = f.game_id
-LEFT JOIN predictions_joined pj ON pj.game_id = f.game_id
+LEFT JOIN ${ref("bgg_predictions")} p ON p.game_id = f.game_id
 LEFT JOIN ${ref("bgg_game_coordinates")} co ON co.game_id = f.game_id
 LEFT JOIN provenance_latest pr ON pr.game_id = f.game_id


### PR DESCRIPTION
## Dataform is still failing on `main`

The previous fix (#91) resolved compilation, but the **execution** then failed:

```
analytics.game_profile => FAILED
Query error: Duplicate field name = first_prediction_ts
```

21 of 22 actions succeeded; only `game_profile` failed. The workflow still exits 1, so
the run is marked failed and the ML pipeline isn't notified.

## Cause

`bgg_predictions` **already** joins `game_first_prediction` and carries
`first_prediction_ts` (plus `is_new_1d` / `is_new_7d`) — see
`definitions/bgg_predictions.sqlx:44-48`. My `predictions_joined` CTE re-joined it, so
`SELECT p.*, fp.first_prediction_ts` produced a duplicate field name.

## Fix

Drop the redundant CTE and join `bgg_predictions` directly, using the whole-row struct.
One fewer table referenced, same output (all model metadata still carried).

## Why the earlier test missed it

A **`SELECT`** tolerates duplicate column names; **`CREATE TABLE` with a struct column
does not**. I validated with a SELECT, and Dataform performs a CREATE — so my test
passed while the real operation failed.

## Verified — with the right check this time

- **`CREATE OR REPLACE TABLE ... AS <model>` dry-run** (the operation Dataform actually
  runs, writes nothing): `game_profile` **OK, 270.8 MB**; `game_neighbors` **OK, 72.3 MB**
- **Dataform compile** of this branch: **0 compilation errors**

Both checks are now part of how I'll validate `.sqlx` changes before merge, rather than
dry-running a bare SELECT.

## Follow-up (not in this PR)

The API's `get_predictions` has the same redundant join (`bgg_predictions LEFT JOIN
game_first_prediction`). It works because it's a SELECT, but it's unnecessary and costs
an extra 10 MB minimum per request. Will fix in PR B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)