### PR TITLE
perf(dataform): partition game_profile by game_id range (clustering alone pruned nothing)

### DIFF
--- a/definitions/game_profile.sqlx
+++ b/definitions/game_profile.sqlx
@@ -4,6 +4,15 @@ config {
   name: "game_profile",
   description: "One row per game holding everything the read API serves for a single game: features, per-player-count recommendations (nested), latest predictions, embedding coordinates and fetch provenance. Collapses a six-query fan-out (~361MB) into one clustered lookup (~10MB) — BigQuery bills a 10MB minimum PER TABLE referenced, so fewer tables matters more than fewer columns. Similar games are deliberately NOT here: neighbour semantics are source-relative and user-tunable (see game_neighbors).",
   bigquery: {
+    // Integer-range partitioning is what actually makes the point lookup cheap.
+    // Clustering alone prunes NOTHING here: cluster pruning needs a table large enough
+    // to span many blocks (~1GB+), and this table is ~273MB, so `WHERE game_id = X`
+    // still scanned the whole table (measured: 273.5MB est -> 273.7MB billed).
+    // With range partitioning the same lookup touches ONE partition:
+    // 1.9MB scanned, billed at the 10MB minimum -- a 96% reduction.
+    // Range goes to 1,000,000 for headroom (max game_id is ~475k today); ids beyond it
+    // still work, they just land in the overflow partition.
+    partitionBy: "RANGE_BUCKET(game_id, GENERATE_ARRAY(0, 1000000, 1000))",
     clusterBy: ["game_id"]
   }
 }


### PR DESCRIPTION
## The problem

`game_profile` built successfully and is clustered by `game_id` — but a single-row
lookup **scanned the entire table**:

```
game_profile WHERE game_id=13    est 273.5M -> billed 273.7M   (0% pruned)
```

So the design's headline saving wasn't real: per-request cost was **284 MB**, only a
21% reduction from the 361 MB baseline — not the ~20 MB I projected.

## Why

**Cluster pruning requires a table large enough to span many blocks (~1 GB+).** At
~273 MB `game_profile` sits in too few blocks, so filtering one `game_id` still reads
them all. This matches what we measured earlier: the larger `core.games` pruned 85.8%,
while both sub-GB `analytics` tables pruned 0%.

I generalised from `core.games` instead of testing a sub-GB table. The "10 MB minimum
per table" I designed around was never the binding constraint here — the full scan was.

## The fix — verified on a scratch copy before committing

```sql
PARTITION BY RANGE_BUCKET(game_id, GENERATE_ARRAY(0, 1000000, 1000))
CLUSTER BY game_id
```

| lookup `game_id=13` | est | billed |
|---|---:|---:|
| clustered only (current) | 273.5 MB | **273.7 MB** |
| partitioned + clustered | 1.9 MB | **10.5 MB** |

**96.2% reduction.** The 10.5 MB billed is just the 10 MB minimum — actual data read is
1.9 MB, i.e. we're at the floor. Partition pruning is deterministic and size-independent,
unlike clustering. The scratch table was dropped after measuring.

Per-request total becomes **~21 MB** (10.5 profile + 10.5 neighbors) vs 361 MB baseline
— the ~94% originally projected, now by a mechanism that demonstrably works.

Range extends to 1,000,000 for headroom (max `game_id` is ~475k today); larger ids still
work, they just land in the overflow partition.

## Verified

- Scratch-table measurement above (the decisive check)
- `CREATE TABLE` dry-run: **OK, 270.8 MB**
- Dataform compile: **0 errors**

## Note

`game_neighbors` needs no partitioning — at 8.7 MB it already bills the 10 MB minimum,
so there is nothing left to prune.

Also useful: **partition pruning shows up in the dry-run estimate** (273.5 → 1.9 MB),
whereas cluster pruning only appears in bytes *billed*. So partitioning is cheap to
verify in future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)