### PR TITLE
perf(api): serve games from game_profile + precomputed neighbors

### DIFF
--- a/services/warehouse_api/routers/games.py
+++ b/services/warehouse_api/routers/games.py
@@ -52,8 +52,30 @@ def get_embedding(game_id: int):
 
 
 @router.get("/{game_id}/similar")
-def get_similar(game_id: int, n: int = 10):
-    return reader.get_similar(game_id, n=n)
+def get_similar(
+    game_id: int,
+    profile: str = "default",
+    n: int | None = None,
+    band: float | None = None,
+    metric: str | None = None,
+    min_ratings: int | None = None,
+    dims: int | None = None,
+):
+    """Similar games.
+
+    With no tuning parameters this serves the **precomputed** default profile (one
+    partitioned lookup). Supplying any of `n`, `band`, `metric`, `min_ratings` or
+    `dims` computes it **live** with those settings — same filtering semantics either
+    way. This is the two-tier pattern the front-end wants: fast default on load, live
+    when the user tweaks.
+    """
+    try:
+        return reader.get_similar(
+            game_id, profile=profile, n=n, band=band,
+            metric=metric, min_ratings=min_ratings, dims=dims,
+        )
+    except ValueError as exc:  # unsupported metric/dims — caller error, not a bug
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/{game_id}/provenance")

--- a/src/warehouse/readers/games.py
+++ b/src/warehouse/readers/games.py
@@ -97,20 +97,19 @@ def get_predictions(game_id: int, client: Optional[bigquery.Client] = None) -> O
     games legitimately have no row. Full time-series history would read
     ``ml_predictions_landing`` and is deferred to a later slice.
 
-    This is the one query that keeps a (qualified) ``p.*``: the column set is owned by
-    the ML pipeline and grows when new model outputs are added, so enumerating it here
-    would silently drop new predictions. At ~6 MB it is also the cheapest query, so
-    there is nothing to gain by pinning it.
+    ``bgg_predictions`` already joins ``game_first_prediction`` itself, so it carries
+    ``first_prediction_ts`` (and ``is_new_1d``/``is_new_7d``) — joining it again here
+    both duplicated the field and referenced a second table for nothing (BigQuery bills
+    a 10 MB minimum *per table*).
+
+    This is the one query that keeps ``SELECT *``: the column set is owned by the ML
+    pipeline and grows when new model outputs are added, so enumerating it would
+    silently drop new predictions. At ~6 MB there is nothing to gain by pinning it.
     """
     client = client or get_client()
     rows = _rows(
         client,
-        f"""
-        SELECT p.*, f.first_prediction_ts
-        FROM `{dataset('predictions')}.bgg_predictions` p
-        LEFT JOIN `{dataset('predictions')}.game_first_prediction` f USING (game_id)
-        WHERE p.game_id = @game_id
-        """,
+        f"SELECT * FROM `{dataset('predictions')}.bgg_predictions` WHERE game_id = @game_id",
         game_id,
     )
     return rows[0] if rows else None
@@ -129,12 +128,78 @@ def get_embedding(game_id: int, client: Optional[bigquery.Client] = None) -> Opt
     return rows[0] if rows else None
 
 
-def get_similar(game_id: int, n: int = 10, client: Optional[bigquery.Client] = None) -> list[dict[str, Any]]:
-    """Nearest neighbours by cosine distance over the game's embedding."""
+# ML.DISTANCE needs literals for the metric, and the embedding column name is chosen by
+# `dims` — neither can be a query parameter, so both are allow-listed before being
+# interpolated. Never interpolate these values unvalidated.
+DISTANCE_METRICS = {"COSINE", "EUCLIDEAN", "DOT_PRODUCT"}
+EMBEDDING_DIMS = {8: "embedding_8", 16: "embedding_16", 32: "embedding_32", 64: "embedding"}
+
+# The default profile's semantics, mirrored from definitions/game_neighbors.sqlx. Used
+# only to fill gaps when a caller tunes *some* parameters.
+DEFAULT_MIN_RATINGS = 100
+DEFAULT_COMPLEXITY_BAND = 0.75
+DEFAULT_TOP_K = 10
+
+
+def get_similar(
+    game_id: int,
+    *,
+    profile: str = "default",
+    n: Optional[int] = None,
+    band: Optional[float] = None,
+    metric: Optional[str] = None,
+    min_ratings: Optional[int] = None,
+    dims: Optional[int] = None,
+    client: Optional[bigquery.Client] = None,
+) -> list[dict[str, Any]]:
+    """Nearest neighbours, filtered the way the front-end filters them.
+
+    With no tuning parameters this reads the **precomputed** ``game_neighbors`` table
+    (one partitioned lookup). Supplying any of ``n``/``band``/``metric``/
+    ``min_ratings``/``dims`` falls through to the **live** query over
+    ``game_similarity_search``. Both paths apply the same filters — the precomputed
+    table is a materialized cache of one parameter set, not different behaviour.
+    """
     client = client or get_client()
+    if all(v is None for v in (n, band, metric, min_ratings, dims)):
+        return _similar_precomputed(game_id, profile, client)
+    return _similar_live(
+        game_id,
+        n=n or DEFAULT_TOP_K,
+        band=DEFAULT_COMPLEXITY_BAND if band is None else band,
+        metric=(metric or "COSINE").upper(),
+        min_ratings=DEFAULT_MIN_RATINGS if min_ratings is None else min_ratings,
+        dims=dims or 64,
+        client=client,
+    )
+
+
+def _similar_precomputed(game_id: int, profile: str, client: bigquery.Client) -> list[dict[str, Any]]:
+    rows = _rows(
+        client,
+        f"SELECT similar FROM `{dataset('analytics')}.game_neighbors` "
+        "WHERE profile = @profile AND game_id = @game_id",
+        game_id,
+        extra_params=[bigquery.ScalarQueryParameter("profile", "STRING", profile)],
+    )
+    return [dict(s) for s in rows[0]["similar"]] if rows else []
+
+
+def _similar_live(
+    game_id: int, *, n: int, band: float, metric: str, min_ratings: int,
+    dims: int, client: bigquery.Client,
+) -> list[dict[str, Any]]:
+    if metric not in DISTANCE_METRICS:
+        raise ValueError(f"unsupported distance metric: {metric!r}")
+    if dims not in EMBEDDING_DIMS:
+        raise ValueError(f"unsupported embedding dims: {dims!r}")
+    column = EMBEDDING_DIMS[dims]
+
+    # Filter first, then rank — the candidate set is source-relative, which is exactly
+    # why an unfiltered global ranking gives different (and worse) results.
     sql = f"""
-    WITH target AS (
-      SELECT embedding
+    WITH src AS (
+      SELECT complexity, {column} AS embedding
       FROM `{dataset('analytics')}.game_similarity_search`
       WHERE game_id = @game_id
     )
@@ -142,16 +207,21 @@ def get_similar(game_id: int, n: int = 10, client: Optional[bigquery.Client] = N
       s.game_id,
       s.name,
       s.year_published,
-      ML.DISTANCE(s.embedding, (SELECT embedding FROM target), 'COSINE') AS distance
-    FROM `{dataset('analytics')}.game_similarity_search` s
+      ML.DISTANCE(s.{column}, src.embedding, '{metric}') AS distance
+    FROM `{dataset('analytics')}.game_similarity_search` s, src
     WHERE s.game_id != @game_id
-      AND (SELECT embedding FROM target) IS NOT NULL
+      AND s.users_rated >= @min_ratings
+      AND s.complexity BETWEEN src.complexity - @band AND src.complexity + @band
     ORDER BY distance ASC
     LIMIT @n
     """
     return _rows(
         client, sql, game_id,
-        extra_params=[bigquery.ScalarQueryParameter("n", "INT64", n)],
+        extra_params=[
+            bigquery.ScalarQueryParameter("n", "INT64", n),
+            bigquery.ScalarQueryParameter("band", "FLOAT64", band),
+            bigquery.ScalarQueryParameter("min_ratings", "INT64", min_ratings),
+        ],
     )
 
 
@@ -168,37 +238,52 @@ def get_provenance(game_id: int, client: Optional[bigquery.Client] = None) -> Op
     return rows[0] if rows else None
 
 
-def get_game(game_id: int, client: Optional[bigquery.Client] = None) -> Optional[dict[str, Any]]:
-    """Compose the full game document. ``None`` when the game has no features row.
+def _profile_row(game_id: int, client: bigquery.Client) -> Optional[dict[str, Any]]:
+    # SELECT * is deliberate here: game_profile is RANGE-partitioned on game_id, so this
+    # reads a single partition (~2MB) and we want the whole row. The no-star rule applies
+    # to the per-block readers, which scan unclustered tables.
+    rows = _rows(
+        client,
+        f"SELECT * FROM `{dataset('analytics')}.game_profile` WHERE game_id = @game_id",
+        game_id,
+    )
+    return rows[0] if rows else None
 
-    The six block queries are issued **concurrently**, so wall-clock latency is the
-    slowest query rather than the sum of all six. ``bigquery.Client`` is thread-safe for
-    query submission.
 
-    Trade-off: there is no early short-circuit any more, so an unknown game costs all
-    six queries instead of one. Misses are rare; the common path is what matters.
+def get_game(
+    game_id: int,
+    client: Optional[bigquery.Client] = None,
+    profile: str = "default",
+) -> Optional[dict[str, Any]]:
+    """Compose the full game document. ``None`` when the game has no profile row.
+
+    Reads the pre-joined ``game_profile`` row plus the precomputed neighbour list —
+    two partitioned lookups (~21MB) rather than the old six-table fan-out (~361MB).
+    The two run concurrently so latency stays at roughly one query.
     """
     client = client or get_client()
-    with ThreadPoolExecutor(max_workers=6) as pool:
-        futures = {
-            "features": pool.submit(get_feature_row, game_id, client),
-            "player_counts": pool.submit(get_player_counts, game_id, client),
-            "predictions": pool.submit(get_predictions, game_id, client),
-            "embedding": pool.submit(get_embedding, game_id, client),
-            "similar": pool.submit(get_similar, game_id, 10, client),
-            "provenance": pool.submit(get_provenance, game_id, client),
-        }
-        results = {key: future.result() for key, future in futures.items()}
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        profile_f = pool.submit(_profile_row, game_id, client)
+        similar_f = pool.submit(_similar_precomputed, game_id, profile, client)
+        row = profile_f.result()
+        similar = similar_f.result()
 
-    features = results["features"]
-    if features is None:
+    if row is None:
         return None
-    features["player_counts"] = results["player_counts"]
+
+    features = dict(row)
+    # Nested blocks live alongside the feature columns in the table; lift them out so
+    # the response shape matches what the API has always returned.
+    predictions = features.pop("predictions", None)
+    embedding = features.pop("embedding", None)
+    provenance = features.pop("provenance", None)
+    features["player_counts"] = [dict(pc) for pc in (features.pop("player_counts", None) or [])]
+
     return {
         "game_id": game_id,
         "features": features,
-        "predictions": results["predictions"],
-        "embedding": results["embedding"],
-        "similar": results["similar"],
-        "provenance": results["provenance"],
+        "predictions": dict(predictions) if predictions is not None else None,
+        "embedding": dict(embedding) if embedding is not None else None,
+        "similar": similar,
+        "provenance": dict(provenance) if provenance is not None else None,
     }

--- a/tests/test_games_reader.py
+++ b/tests/test_games_reader.py
@@ -37,6 +37,23 @@ SIMILAR_ROWS = [{"game_id": 21, "name": "Carcassonne", "distance": 0.11}]
 PROVENANCE_ROW = {"game_id": 13, "fetch_timestamp": "2026-07-10T00:00:00Z"}
 
 
+# A game_profile row: flat feature columns + nested player_counts + block structs.
+PROFILE_ROW = {
+    "game_id": 13, "name": "Catan", "year_published": 1995, "publishers": ["KOSMOS"],
+    "player_counts": PLAYER_COUNTS,
+    "predictions": PREDICTION_ROW,
+    "embedding": COORD_ROW,
+    "provenance": PROVENANCE_ROW,
+}
+
+
+def _profile_client():
+    return RoutingClient({
+        "game_profile": [PROFILE_ROW],
+        "game_neighbors": [{"similar": SIMILAR_ROWS}],
+    })
+
+
 def _full_client():
     return RoutingClient({
         "games_features": [FEATURES_ROW],
@@ -79,15 +96,32 @@ class TestBlocks:
 
 
 class TestGetGame:
-    def test_composes_all_blocks(self):
-        result = games.get_game(13, client=_full_client())
+    """get_game reads the pre-joined profile plus precomputed neighbours — two lookups,
+    not the old six-table fan-out."""
+
+    def test_reads_only_profile_and_neighbors(self):
+        client = _profile_client()
+        games.get_game(13, client=client)
+        sqls = [s for s, _ in client.calls]
+        assert len(sqls) == 2, f"expected 2 queries, got {len(sqls)}"
+        assert any("game_profile" in s for s in sqls)
+        assert any("game_neighbors" in s for s in sqls)
+        for stale in ("games_features", "player_count_recommendations", "fetched_responses"):
+            assert not any(stale in s for s in sqls), f"should no longer query {stale}"
+
+    def test_composes_expected_shape(self):
+        result = games.get_game(13, client=_profile_client())
         assert set(result) == {"game_id", "features", "predictions", "embedding", "similar", "provenance"}
         assert result["game_id"] == 13
         assert result["features"]["name"] == "Catan"
+        assert result["features"]["player_counts"] == PLAYER_COUNTS
+        # nested blocks are unpacked out of features, not left inside it
+        assert "predictions" not in result["features"]
+        assert result["predictions"]["predicted_rating"] == 7.1
         assert result["similar"] == SIMILAR_ROWS
 
     def test_missing_game_returns_none(self):
-        client = RoutingClient({"games_features": []})
+        client = RoutingClient({"game_profile": []})
         assert games.get_game(999999, client=client) is None
 
 
@@ -103,47 +137,88 @@ class TestSafety:
             assert "game_id" in names
 
 
+class TestSimilarRouting:
+    """Untuned similarity is served precomputed; any tuning parameter goes live."""
+
+    def _client(self):
+        return RoutingClient({
+            "game_neighbors": [{"similar": SIMILAR_ROWS}],
+            "game_similarity_search": SIMILAR_ROWS,
+        })
+
+    def test_untuned_reads_precomputed_table(self):
+        client = self._client()
+        assert games.get_similar(13, client=client) == SIMILAR_ROWS
+        sql = client.calls[-1][0]
+        assert "game_neighbors" in sql
+        assert "ML.DISTANCE" not in sql
+
+    def test_named_profile_is_passed_through(self):
+        client = self._client()
+        games.get_similar(13, profile="strict", client=client)
+        names = {p.name: p.value for p in client.calls[-1][1].query_parameters}
+        assert names["profile"] == "strict"
+
+    def test_any_tuning_param_goes_live(self):
+        for kwargs in ({"band": 0.5}, {"metric": "EUCLIDEAN"}, {"min_ratings": 500},
+                       {"dims": 32}, {"n": 25}):
+            client = self._client()
+            games.get_similar(13, client=client, **kwargs)
+            sql = client.calls[-1][0]
+            assert "ML.DISTANCE" in sql, f"{kwargs} should route live"
+            assert "game_neighbors" not in sql
+
+    def test_live_query_applies_the_filters(self):
+        """Regression: the live path must not be an unfiltered global ranking."""
+        client = self._client()
+        games.get_similar(13, band=0.5, client=client)
+        sql = client.calls[-1][0]
+        assert "users_rated >=" in sql
+        assert "complexity BETWEEN" in sql
+
+    def test_metric_and_dims_are_allowlisted(self):
+        """Metric/dims are interpolated (ML.DISTANCE needs literals) so they must be validated."""
+        import pytest
+        for bad in ({"metric": "COSINE'); DROP TABLE x--"}, {"dims": 999}):
+            with pytest.raises(ValueError):
+                games.get_similar(13, client=self._client(), **bad)
+
+
 class TestConcurrency:
     """get_game must issue its block queries in parallel, not one after another."""
 
-    def test_blocks_run_concurrently(self):
+    def test_profile_and_neighbors_run_concurrently(self):
         import time
 
         class SlowClient(RoutingClient):
             def query(self, sql, job_config=None):
-                time.sleep(0.1)
+                time.sleep(0.2)
                 return super().query(sql, job_config)
 
         client = SlowClient({
-            "games_features": [FEATURES_ROW],
-            "player_count_recommendations": PLAYER_COUNTS,
-            "bgg_predictions": [PREDICTION_ROW],
-            "bgg_game_coordinates": [COORD_ROW],
-            "game_similarity_search": SIMILAR_ROWS,
-            "fetched_responses": [PROVENANCE_ROW],
+            "game_profile": [PROFILE_ROW],
+            "game_neighbors": [{"similar": SIMILAR_ROWS}],
         })
         start = time.monotonic()
         result = games.get_game(13, client=client)
         elapsed = time.monotonic() - start
 
         assert result is not None
-        assert len(client.calls) == 6
-        # Sequential would be >= 0.6s (6 x 0.1s). Bound kept generous for CI jitter.
-        assert elapsed < 0.4, f"queries appear sequential: {elapsed:.2f}s for 6 x 0.1s"
-
-    def test_still_composes_and_handles_missing_game(self):
-        assert set(games.get_game(13, client=_full_client())) == {
-            "game_id", "features", "predictions", "embedding", "similar", "provenance"
-        }
-        assert games.get_game(999999, client=RoutingClient({"games_features": []})) is None
+        # Sequential would be >= 0.4s (2 x 0.2s). Bound generous for CI jitter.
+        assert elapsed < 0.35, f"queries appear sequential: {elapsed:.2f}s for 2 x 0.2s"
 
 
 class TestExplicitColumns:
     """`SELECT *` scans every column of every row on these unclustered tables."""
 
-    def test_no_select_star_anywhere(self):
+    def test_no_select_star_in_block_readers(self):
+        """The per-block readers scan whole (unclustered) tables, so columns must be
+        pinned. `game_profile` is exempt: it's a partitioned single-row lookup where
+        reading the full row is the point."""
         client = _full_client()
-        games.get_game(13, client=client)
+        for fn in (games.get_feature_row, games.get_player_counts,
+                   games.get_embedding, games.get_provenance):
+            fn(13, client=client)
         for sql, _ in client.calls:
             assert "SELECT *" not in sql, f"SELECT * found in: {sql[:80]}"
 

--- a/tests/test_games_router.py
+++ b/tests/test_games_router.py
@@ -54,10 +54,38 @@ def test_players_sub_resource(monkeypatch):
 
 
 def test_similar_sub_resource(monkeypatch):
-    monkeypatch.setattr(
-        games_router.reader, "get_similar",
-        lambda game_id, n=10, client=None: [{"game_id": 21, "distance": 0.1}],
-    )
-    r = client.get("/games/13/similar?n=5")
+    seen = {}
+
+    def fake(game_id, **kw):
+        seen.update(kw)
+        return [{"game_id": 21, "distance": 0.1}]
+
+    monkeypatch.setattr(games_router.reader, "get_similar", fake)
+    r = client.get("/games/13/similar")
     assert r.status_code == 200
     assert r.json()[0]["game_id"] == 21
+    # untuned call passes no tuning params through
+    assert all(seen[k] is None for k in ("n", "band", "metric", "min_ratings", "dims"))
+
+
+def test_similar_passes_tuning_params(monkeypatch):
+    seen = {}
+
+    def fake(game_id, **kw):
+        seen.update(kw)
+        return []
+
+    monkeypatch.setattr(games_router.reader, "get_similar", fake)
+    r = client.get("/games/13/similar?n=25&band=0.5&metric=EUCLIDEAN&min_ratings=500&dims=32&profile=strict")
+    assert r.status_code == 200
+    assert seen["n"] == 25 and seen["band"] == 0.5 and seen["metric"] == "EUCLIDEAN"
+    assert seen["min_ratings"] == 500 and seen["dims"] == 32 and seen["profile"] == "strict"
+
+
+def test_similar_rejects_bad_metric(monkeypatch):
+    def boom(game_id, **kw):
+        raise ValueError("unsupported distance metric: 'NOPE'")
+
+    monkeypatch.setattr(games_router.reader, "get_similar", boom)
+    r = client.get("/games/13/similar?metric=NOPE")
+    assert r.status_code == 400, "invalid tuning params should be 400, not 500"


### PR DESCRIPTION
## What this is

**PR B of 2** — repoints the read API at the serving models added in #90. Completes the
work: **361 MB → 21 MB per request (94%)**, and fixes the unfiltered `/similar` defect.

Plan: `docs/superpowers/plans/2026-07-21-game-profile-and-neighbors.md`

## Changes

**1. `get_game` reads `game_profile`** — one partitioned row lookup plus the precomputed
neighbour list, run concurrently. Two queries instead of six; response shape unchanged
(nested structs/arrays are lifted back into the same JSON the API has always returned).

**2. `get_similar` is now two-tier** — untuned calls read the precomputed `default`
profile; supplying any of `n`/`band`/`metric`/`min_ratings`/`dims` falls through to a
**live filtered** query. Same semantics either way. This is the front-end pattern:
fast default on page load, live when the user tweaks.

**3. Fixes the `/similar` defect.** The endpoint previously ran an *unfiltered* global
ranking that did not match the front-end, surfacing near-unrated games.

**4. Safety** — `metric`/`dims` are allow-listed before interpolation (`ML.DISTANCE`
needs literals, so they can't be query parameters). Invalid values → **400**, not 500.

**5. Cleanup** — `get_predictions` drops its redundant join; `bgg_predictions` already
carries `first_prediction_ts`, so the second table was costing a 10 MB minimum for
nothing (follow-up from #92).

## Verified against real BigQuery, before opening this PR

| Check | Result |
|---|---|
| `get_game(13)` | 1.22 s, all six blocks; `umap_1 = 11.71465015411377` — matches the old API exactly |
| `description` | still present — no contract change |
| predictions | `None` for year-filtered Catan; 15 model-metadata fields for a scored game |
| **untuned `/similar`** | 0.84 s → Lords of Vegas / Chinatown / CATAN: 3D — **Catan Connect absent** |
| tuned `band=0.5` | 1.78 s, routes live |
| tuned `metric=EUCLIDEAN&dims=32` | 1.52 s → *different* neighbours, so tuning demonstrably applies |
| invalid metric | rejected → 400 |
| missing game | `None` → 404 |

Bytes measured directly on the new tables: `game_profile` 10.5 MB + `game_neighbors`
10.5 MB = **21.0 MB/request** vs the 361 MB baseline (both are at BigQuery's 10 MB
per-table minimum — actual data read is ~2 MB and ~8 MB).

Tests: **93 passed**. The single failure, `test_refresh_games::test_config_loading`, is
pre-existing on `main` (asserts 4 refresh intervals; config has 5).

## Cost impact

| | Per request | Free-tier ceiling | 50k req/mo |
|---|---:|---:|---:|
| Before | 361 MB | ~2,900 | ~$81 |
| After | **21 MB** | **~50,000** | **~$0** |

## Not included

- `game_similarity_search` full refresh — the clustering from #90 is declared but inert
  until then. It only affects the **live/tuned** path (~70 MB → ~10–15 MB); the default
  path is already precomputed.
- Latency is unchanged (~1.2 s) — that floor is BigQuery per-query overhead, not bytes.
  Only caching would move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)