### PR TITLE
fix(dataform): remove invalid clusterBy from game_similarity_search

### DIFF
--- a/definitions/game_similarity_search.sqlx
+++ b/definitions/game_similarity_search.sqlx
@@ -3,16 +3,7 @@ config {
   schema: "analytics",
   name: "game_similarity_search",
   uniqueKey: ["game_id"],
-  description: "Game embeddings enriched with features for similarity search. Combines embeddings from predictions with game metadata for filtering by year, rating, complexity, etc. Clustered on users_rated + complexity: the similarity query filters on THOSE columns (never on game_id) and then ranks every survivor, so clustering by game_id would prune nothing.",
-  bigquery: {
-    // Deliberately NOT game_id. Live similarity filters `users_rated >= N` (applied on
-    // essentially every query; alone cuts 127,645 -> 17,258 rows, ~86%) and then a
-    // source-relative complexity band, before ranking. users_rated is therefore the
-    // right prefix key, with complexity second for the band tweak.
-    // NOTE: clustering cannot be added to an existing table in place -- this needs a
-    // FULL REFRESH to take effect (see 2026-03-31-dataform-incremental-schema-drift).
-    clusterBy: ["users_rated", "complexity"]
-  }
+  description: "Game embeddings enriched with features for similarity search. Combines embeddings from predictions with game metadata for filtering by year, rating, complexity, etc. NOT clustered/partitioned: measurement showed no table layout prunes the live similarity query, because its self-join to the source embedding defeats pruning (a plain filtered scan prunes 67MB->9MB; the joined query stays ~68MB). The default similarity path is served precomputed from game_neighbors; this table is only hit for tuned/custom similarity, which is rare and ~$0.0003/call."
 }
 
 SELECT


### PR DESCRIPTION
## What

Removes the `clusterBy: ["users_rated", "complexity"]` I added to
`game_similarity_search` in #90.

## Why it has to go

1. **It's invalid.** `complexity` is a FLOAT, and BigQuery rejects float cluster keys
   (`CLUSTER BY expression may not be a floating point type`). The clustering never
   applied because the table was first built without it and normal incremental runs
   `MERGE` rather than recreate — but **any full refresh would now fail**. It's a
   latent landmine.

2. **It wouldn't have helped anyway.** Measured on scratch copies: no table layout
   prunes the live similarity query, because its self-join to the source embedding
   defeats pruning.

   | | bytes |
   |---|---|
   | live tuned query — current | 71.3 MB |
   | live tuned query — clustered by users_rated | 71.3 MB (+0%) |
   | live tuned query — partitioned by users_rated | 71.3 MB (+0%) |
   | plain filtered scan, partitioned (no join) | 9.1 MB (67→9) |

   The plain scan proves the *data* prunes; the join is what blocks it. So the tuned
   path is a query-restructure problem, not a table-layout one — and it isn't hot enough
   to be worth restructuring.

## Impact

None on cost or behaviour. The **default** similarity path is served precomputed from
`game_neighbors` (~10 MB). This table is only touched for **tuned/custom** similarity —
rare, ~$0.0003/call — and stays at ~71 MB there. This PR only defuses a broken config.

Verified: Dataform compile — **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)