### PR TITLE
feat(dataform): sample_status and training_cutoff_year on bgg_predictions

### DIFF
--- a/definitions/bgg_predictions.sqlx
+++ b/definitions/bgg_predictions.sqlx
@@ -16,6 +16,10 @@ WITH source_data AS (
     predicted_rating,
     predicted_users_rated,
     predicted_geek_rating,
+    -- Whether the scoring models were fitted on this game's year. Emitted by the
+    -- scorer from the loaded model's registration, so it stays honest across a refit.
+    sample_status,
+    training_cutoff_year,
     geek_rating_model_name,
     geek_rating_model_version,
     geek_rating_experiment,


### PR DESCRIPTION
Carries the two new prediction fields through to `bgg_predictions`.

## Blocked on bgg-predictive-models#62

That PR adds `sample_status` and `training_cutoff_year` to `ml_predictions_landing`. Until its terraform applies, a `CREATE TABLE` dry-run of this model fails with `Unrecognized name: sample_status` — which is the expected and correct failure.

## Deploy requires a full refresh

`bgg_predictions` is `incremental`. Dataform will not `ALTER` an existing table, so this needs a targeted full refresh, **not** an ordinary run. Do not let a scheduled run hit the merged model first.

## Ordering

1. Merge and deploy bgg-predictive-models#62
2. Run the rated-game backfill (~30k games, ~40 min)
3. Merge this, then immediately full-refresh `bgg_predictions`

Backfill before refresh, so one refresh absorbs both the new columns and the new rows.

## Safety

`bgg_predictions` holds nothing of its own — it is the latest row per `game_id` from the append-only `ml_predictions_landing`, so it is fully reconstructible. `first_prediction_ts` comes from `game_first_prediction`, a plain table over the same landing data, so a refresh cannot reset it.

Optional snapshot before the refresh:

```
bq cp bgg-data-warehouse:predictions.bgg_predictions \
      bgg-data-warehouse:predictions.bgg_predictions_pre_backfill
```

## Validation so far

- `dataform compile` — no errors; both columns present in the compiled query
- `CREATE TABLE` dry-run — fails only on the missing landing columns; to be re-run once #62 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)