### PR TITLE
feat(terraform): dedicated bgg-viewer SA, IAM, and secret containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,9 @@ Thumbs.db
 scratch/
 
 src/debug
+
+# Terraform
+terraform/.terraform/
+*.tfstate
+*.tfstate.*
+tfplan

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,3 +17,7 @@ output "service_account_email" {
 output "artifact_registry_repository" {
   value = google_artifact_registry_repository.bgg_images.name
 }
+
+output "bgg_viewer_service_account" {
+  value = google_service_account.bgg_viewer.email
+}

--- a/terraform/viewer.tf
+++ b/terraform/viewer.tf
@@ -1,0 +1,120 @@
+# =============================================================================
+# bgg-viewer — SvelteKit front-end on Cloud Run (public URL, app-level login gate).
+#
+# Dedicated least-privilege SA rather than reusing bgg-data-warehouse@ (which
+# bgg-dash-viewer and the warehouse API share): the viewer's warehouse-API invoker
+# grant then names this app specifically, and its BigQuery access can be revoked
+# without touching the pipeline. Same rationale as bgg-thing-ids-scraper in iam.tf.
+#
+# The Cloud Run *service* is deployed by the app repo's release-please workflow
+# (bgg-viewer/.github/workflows/release-please.yml). Terraform owns identity, IAM,
+# and the secret containers only — never the service, never the secret values.
+#
+# See bgg-viewer/docs/superpowers/specs/2026-08-03-deployment-design.md
+# =============================================================================
+
+resource "google_service_account" "bgg_viewer" {
+  account_id   = "bgg-viewer"
+  display_name = "BGG Viewer (SvelteKit front-end)"
+  description  = "Runtime SA for the bgg-viewer Cloud Run service"
+  project      = var.project_id
+}
+
+# --- BigQuery ---------------------------------------------------------------
+
+# Run query jobs. jobUser is project-scoped; there is no narrower form.
+resource "google_project_iam_member" "bgg_viewer_job_user" {
+  project = var.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.bgg_viewer.email}"
+}
+
+# The catalog artifact joins analytics.games_features + analytics.best_player_counts.
+resource "google_bigquery_dataset_iam_member" "bgg_viewer_analytics_viewer" {
+  dataset_id = google_bigquery_dataset.bgg_analytics.dataset_id
+  project    = var.project_id
+  role       = "roles/bigquery.dataViewer"
+  member     = "serviceAccount:${google_service_account.bgg_viewer.email}"
+}
+
+# ...and predictions.bgg_predictions. The `predictions` dataset is NOT managed by this
+# Terraform config (only core/raw/analytics are), so the id is literal. This member
+# resource is non-authoritative, so it adds a grant without disturbing existing ones.
+resource "google_bigquery_dataset_iam_member" "bgg_viewer_predictions_viewer" {
+  dataset_id = "predictions"
+  project    = var.project_id
+  role       = "roles/bigquery.dataViewer"
+  member     = "serviceAccount:${google_service_account.bgg_viewer.email}"
+}
+
+# core.users is read on login and WRITTEN on registration, so dataEditor, not
+# dataViewer. Dataset-scoped: the viewer must not reach `raw`.
+resource "google_bigquery_dataset_iam_member" "bgg_viewer_core_editor" {
+  dataset_id = google_bigquery_dataset.bgg_data.dataset_id
+  project    = var.project_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${google_service_account.bgg_viewer.email}"
+}
+
+# --- Warehouse read API -----------------------------------------------------
+# The run.invoker grant lives in warehouse_api.tf, whose authoritative binding is the
+# single source of truth for that service's allow-list. Adding it here would fight it.
+
+# --- Secrets ----------------------------------------------------------------
+# Containers only. Versions are created manually with `gcloud secrets versions add`
+# so no secret value ever enters git or Terraform state.
+
+resource "google_secret_manager_secret" "bgg_viewer_session_secret" {
+  secret_id = "bgg-viewer-session-secret"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    environment = var.environment
+    managed_by  = "terraform"
+    purpose     = "auth"
+  }
+}
+
+resource "google_secret_manager_secret" "bgg_viewer_registration_code" {
+  secret_id = "bgg-viewer-registration-code"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    environment = var.environment
+    managed_by  = "terraform"
+    purpose     = "auth"
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "bgg_viewer_session_secret_access" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.bgg_viewer_session_secret.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.bgg_viewer.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "bgg_viewer_registration_code_access" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.bgg_viewer_registration_code.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.bgg_viewer.email}"
+}
+
+# --- Deploy-time permission -------------------------------------------------
+# The CI identity (bgg-data-warehouse@, via GCP_SA_KEY_BGG_DW) already holds run.admin
+# and artifactregistry.writer from iam.tf. It additionally needs serviceAccountUser on
+# THIS SA to deploy a service that runs as it — without this, `gcloud run deploy`
+# fails with "iam.serviceaccounts.actAs" denied.
+resource "google_service_account_iam_member" "bgg_viewer_ci_act_as" {
+  service_account_id = google_service_account.bgg_viewer.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.bgg_pipeline.email}"
+}

--- a/terraform/warehouse_api.tf
+++ b/terraform/warehouse_api.tf
@@ -22,8 +22,14 @@ variable "warehouse_api_invoker_members" {
     (A "group:..." member is possible too, but a group's membership is managed outside
     Terraform/Actions — prefer listing identities directly here.)
   EOT
-  type    = list(string)
-  default = ["user:phil.henrickson@gmail.com"]
+  type        = list(string)
+  default = [
+    "user:phil.henrickson@gmail.com",
+    # bgg-viewer's Cloud Run runtime SA. In prod the viewer mints an ID token for
+    # ITS OWN identity (src/lib/server/warehouse/token.ts -> mintIdToken), not a
+    # user's, so without this every game detail page 403s. See terraform/viewer.tf.
+    "serviceAccount:bgg-viewer@bgg-data-warehouse.iam.gserviceaccount.com",
+  ]
 }
 
 resource "google_cloud_run_v2_service_iam_binding" "warehouse_api_invokers" {


### PR DESCRIPTION
Infrastructure for deploying [bgg-viewer](https://github.com/phenrickson/bgg-viewer) to Cloud Run. Terraform owns identity, IAM, and secret containers; the service itself is deployed from the app repo.

## What this adds

`terraform/viewer.tf` — a dedicated `bgg-viewer@` service account rather than reusing the shared `bgg-data-warehouse@` SA, so the viewer's warehouse-API grant names this app specifically and its BigQuery access can be revoked without touching the pipeline. Same rationale as `bgg-thing-ids-scraper` in `iam.tf`.

Grants:
- `roles/bigquery.jobUser` (project — no narrower scope exists)
- `roles/bigquery.dataViewer` on `analytics` (catalog joins `games_features` + `best_player_counts`) and `predictions` (`bgg_predictions`)
- `roles/bigquery.dataEditor` on `core` — registration **writes** `core.users`, so viewer is not enough
- `roles/secretmanager.secretAccessor` on the two auth secrets
- `roles/iam.serviceAccountUser` for the CI identity, so `gcloud run deploy` can act as the new SA

## The important bit

`warehouse_api.tf` gains the viewer SA in `warehouse_api_invoker_members`. In production the viewer mints an ID token for **its own service account** (`src/lib/server/warehouse/token.ts` → `mintIdToken`), not a user identity. That binding is authoritative and currently lists only `user:phil.henrickson@gmail.com`, so without this **every game detail page 403s**.

## Secrets

Containers only — `bgg-viewer-session-secret` and `bgg-viewer-registration-code`. Values are added manually with `gcloud secrets versions add` after apply, so no secret value enters git or Terraform state.

## Notes

- The `predictions` dataset isn't managed by this config (only `core`/`raw`/`analytics` are), so its grant uses a literal `dataset_id`. The member resource is non-authoritative and leaves existing grants intact. **If that dataset doesn't exist, apply will 404** — plan can't catch it.
- `.gitignore` gains `terraform/.terraform/` and `*.tfstate*`; the repo had no Terraform entries, so a provider cache could be committed by an accidental `git add -A`.

## Verification

`terraform fmt -check`, `validate`, and `plan` all pass locally. Plan is **10 to add, 1 to change, 0 to destroy** — the single in-place change is the invoker binding gaining the viewer SA alongside the existing user.

Please confirm the CI plan matches before merging; merging applies.

Design: `bgg-viewer/docs/superpowers/specs/2026-08-03-deployment-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)