### PR TITLE
feat(api): add GET /new-games endpoint

### DIFF
--- a/services/warehouse_api/main.py
+++ b/services/warehouse_api/main.py
@@ -1,7 +1,8 @@
 """BGG Warehouse read API.
 
 A modular-monolith FastAPI service over the warehouse's materialized data. One router
-per resource; this build ships ``/health`` and the ``games`` router. See
+per resource; this build ships ``/health``, the ``games`` router, and the
+``monitoring`` router. See
 docs/superpowers/specs/2026-07-16-warehouse-services-architecture-design.md.
 """
 
@@ -10,7 +11,7 @@ import logging
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
-from services.warehouse_api.routers import games
+from services.warehouse_api.routers import games, monitoring
 
 load_dotenv()
 logging.basicConfig(level=logging.INFO)
@@ -18,6 +19,7 @@ logging.basicConfig(level=logging.INFO)
 app = FastAPI(title="BGG Warehouse API", version="0.1.0")
 
 app.include_router(games.router)
+app.include_router(monitoring.router)
 
 
 @app.get("/health")

--- a/services/warehouse_api/routers/monitoring.py
+++ b/services/warehouse_api/routers/monitoring.py
@@ -1,0 +1,20 @@
+"""Monitoring resource router.
+
+Thin HTTP shell over ``src.warehouse.readers.monitoring``, same shape as
+``routers.games``. Serves bgg-viewer's "what's new" page.
+"""
+
+from fastapi import APIRouter, Query
+
+from src.warehouse.readers import monitoring as reader
+
+router = APIRouter(tags=["monitoring"])
+
+
+@router.get("/new-games")
+def get_new_games(
+    days: int = Query(7, ge=1, le=365),
+    limit: int = Query(200, ge=1, le=1000),
+):
+    """Games first fetched into the warehouse in the last `days` days, newest first."""
+    return reader.fetch_recently_added(days_back=days, limit=limit)

--- a/src/warehouse/readers/monitoring.py
+++ b/src/warehouse/readers/monitoring.py
@@ -1,0 +1,49 @@
+"""Reader for the 'what's new' monitoring view.
+
+Games recently added to the warehouse, for bgg-viewer's /whats-new page. Separate
+from ``readers.games`` because this reads across games rather than looking one up.
+"""
+
+from typing import Any, Optional
+
+from google.cloud import bigquery
+
+from src.warehouse.bq import dataset, get_client
+
+
+def fetch_recently_added(
+    days_back: int = 7,
+    limit: int = 200,
+    client: Optional[bigquery.Client] = None,
+) -> list[dict[str, Any]]:
+    """Games first fetched in the last ``days_back`` days, newest first.
+
+    ``first_seen`` is ``MIN(fetch_timestamp)`` per ``game_id`` from
+    ``raw.fetched_responses`` — the same definition bgg-dash-viewer's
+    ``/app/new-games`` page already uses. ``predicted_hurdle_prob`` is returned
+    raw/unthresholded; any tiering is a display decision made by the caller.
+    """
+    client = client or get_client()
+    sql = f"""
+        WITH first_fetches AS (
+            SELECT game_id, MIN(fetch_timestamp) AS first_seen
+            FROM `{dataset('raw')}.fetched_responses`
+            WHERE fetch_status = 'success'
+            GROUP BY game_id
+        )
+        SELECT g.game_id, g.name, g.year_published, g.thumbnail,
+               ff.first_seen, p.predicted_hurdle_prob
+        FROM first_fetches ff
+        JOIN `{dataset('analytics')}.games_features` g USING (game_id)
+        LEFT JOIN `{dataset('predictions')}.bgg_predictions` p USING (game_id)
+        WHERE ff.first_seen > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL @days_back DAY)
+        ORDER BY ff.first_seen DESC
+        LIMIT @limit
+    """
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter("days_back", "INT64", days_back),
+            bigquery.ScalarQueryParameter("limit", "INT64", limit),
+        ]
+    )
+    return [dict(row) for row in client.query(sql, job_config=job_config).result()]

--- a/tests/test_monitoring_reader.py
+++ b/tests/test_monitoring_reader.py
@@ -1,0 +1,75 @@
+"""Unit tests for the monitoring reader (BigQuery mocked — no network)."""
+
+from src.warehouse.readers import monitoring
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def result(self):
+        return self._rows
+
+
+class FakeClient:
+    """Fake BigQuery client for a single joined query — records the call so tests
+    can assert on the SQL shape and the bound parameters."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self.calls = []
+
+    def query(self, sql, job_config=None):
+        self.calls.append((sql, job_config))
+        return _Result(list(self.rows))
+
+
+ROW = {
+    "game_id": 13,
+    "name": "Catan",
+    "year_published": 1995,
+    "thumbnail": "https://example.com/catan.jpg",
+    "first_seen": "2026-08-10T00:00:00Z",
+    "predicted_hurdle_prob": 0.62,
+}
+
+
+def _params(job_config):
+    return {p.name: p.value for p in job_config.query_parameters}
+
+
+def test_returns_rows_as_dicts():
+    client = FakeClient([ROW])
+    result = monitoring.fetch_recently_added(days_back=30, limit=50, client=client)
+    assert result == [ROW]
+
+
+def test_query_joins_fetched_responses_features_and_predictions():
+    client = FakeClient([])
+    monitoring.fetch_recently_added(client=client)
+    sql, _ = client.calls[0]
+    assert "fetched_responses" in sql
+    assert "games_features" in sql
+    assert "bgg_predictions" in sql
+    assert "MIN(fetch_timestamp)" in sql
+    assert "LEFT JOIN" in sql  # predictions must not drop games with no prediction row
+
+
+def test_days_back_and_limit_are_bound_parameters_not_interpolated():
+    client = FakeClient([])
+    monitoring.fetch_recently_added(days_back=42, limit=7, client=client)
+    sql, job_config = client.calls[0]
+    assert "42" not in sql
+    assert "7 " not in sql and not sql.rstrip().endswith("7")
+    params = _params(job_config)
+    assert params["days_back"] == 42
+    assert params["limit"] == 7
+
+
+def test_defaults_are_7_days_and_200_rows():
+    client = FakeClient([])
+    monitoring.fetch_recently_added(client=client)
+    _, job_config = client.calls[0]
+    params = _params(job_config)
+    assert params["days_back"] == 7
+    assert params["limit"] == 200

--- a/tests/test_monitoring_router.py
+++ b/tests/test_monitoring_router.py
@@ -1,0 +1,44 @@
+"""Router tests for the monitoring resource (reader mocked — no BigQuery)."""
+
+from fastapi.testclient import TestClient
+
+from services.warehouse_api.main import app
+from services.warehouse_api.routers import monitoring as monitoring_router
+
+client = TestClient(app)
+
+
+def test_new_games_defaults(monkeypatch):
+    seen = {}
+
+    def fake(days_back, limit):
+        seen.update(days_back=days_back, limit=limit)
+        return [{"game_id": 13, "name": "Catan"}]
+
+    monkeypatch.setattr(monitoring_router.reader, "fetch_recently_added", fake)
+    r = client.get("/new-games")
+    assert r.status_code == 200
+    assert r.json() == [{"game_id": 13, "name": "Catan"}]
+    assert seen == {"days_back": 7, "limit": 200}
+
+
+def test_new_games_passes_days_and_limit(monkeypatch):
+    seen = {}
+
+    def fake(days_back, limit):
+        seen.update(days_back=days_back, limit=limit)
+        return []
+
+    monkeypatch.setattr(monitoring_router.reader, "fetch_recently_added", fake)
+    r = client.get("/new-games?days=30&limit=50")
+    assert r.status_code == 200
+    assert seen == {"days_back": 30, "limit": 50}
+
+
+def test_new_games_rejects_out_of_range_days(monkeypatch):
+    monkeypatch.setattr(
+        monitoring_router.reader, "fetch_recently_added",
+        lambda days_back, limit: [],
+    )
+    assert client.get("/new-games?days=0").status_code == 422
+    assert client.get("/new-games?days=366").status_code == 422


### PR DESCRIPTION
## Summary
- Adds a `monitoring` reader (`src/warehouse/readers/monitoring.py`) and router (`services/warehouse_api/routers/monitoring.py`) exposing `GET /new-games?days=&limit=`
- Games first fetched into the warehouse in the last `days` days (default 7, max 365), newest first, joined to `games_features` for display fields and `bgg_predictions` (left join) for a raw, unthresholded `predicted_hurdle_prob`
- Same `first_seen = MIN(fetch_timestamp)` definition bgg-dash-viewer's own `/app/new-games` page already uses — no new BigQuery access needed, warehouse-api's runtime SA already reads `raw`/`analytics`/`predictions` (see `readers/games.py::get_provenance` for precedent)
- Backs bgg-viewer's upcoming `/whats-new` page — spec/plan at `bgg-viewer/docs/superpowers/specs/2026-08-18-whats-new-design.md` and `.../plans/2026-08-18-whats-new.md`

## Test plan
- [x] `uv run --extra test python -m pytest tests/test_monitoring_reader.py tests/test_monitoring_router.py` — 7/7 pass
- [x] Full suite: 101 passed, 1 pre-existing unrelated failure (`test_refresh_games.py::test_config_loading`, response-refresh interval config — not touched by this change)
- [ ] After merge: `curl https://<warehouse-api-url>/new-games?days=7` against the deployed service with a valid ID token

🤖 Generated with [Claude Code](https://claude.com/claude-code)