### PR TITLE
docs(terraform): note manual boardgame-viz.com domain mapping

### DIFF
--- a/terraform/viewer.tf
+++ b/terraform/viewer.tf
@@ -10,6 +10,11 @@
 # (bgg-viewer/.github/workflows/release-please.yml). Terraform owns identity, IAM,
 # and the secret containers only — never the service, never the secret values.
 #
+# Custom domain: boardgame-viz.com is mapped to the service via a one-time manual
+# `gcloud run domain-mappings create` run under a personal account (domain mapping
+# requires the identity that verified ownership in Search Console — the CI service
+# account isn't a verified owner). Not Terraform-managed; not tracked elsewhere.
+#
 # See bgg-viewer/docs/superpowers/specs/2026-08-03-deployment-design.md
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- Documents that the `boardgame-viz.com` custom domain mapping for `bgg-viewer` was created manually via `gcloud run domain-mappings create`, not Terraform
- Domain mapping creation requires the identity that verified ownership in Search Console (a personal account), which the CI service account isn't set up to be

## Test plan
- N/A — comment-only change, no infrastructure affected